### PR TITLE
Add admin SPA frontend and extend guest API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,102 @@
 # realPMS
-Ein wunderschönes PMS
+
+Ein wunderschönes PMS – jetzt mit ersten Setup-Skripten.
+
+## Installation der Datenbanktabellen
+
+1. Erstelle eine `.env` oder `install.config.php` Datei mit den MySQL-Zugangsdaten **und** einem API-Token:
+   ```ini
+   DB_HOST=127.0.0.1
+   DB_PORT=3306
+   DB_DATABASE=realpms
+   DB_USERNAME=realpms_user
+   DB_PASSWORD=geheimespasswort
+    API_TOKEN=mein-ultra-sicheres-token
+   ```
+   Alternativ kannst du `install.config.php` auf Basis von `install.config.php.example` anpassen.
+2. Führe den Installer per CLI aus:
+   ```bash
+   php install.php
+   ```
+   oder rufe `install.php` im Browser auf. Die Skriptausgabe bestätigt die Erstellung aller Tabellen.
+
+## Repository-Update über das Backend
+
+Für ein automatisiertes Update des aktuell ausgecheckten Branches steht `backend/update.php` bereit.
+
+1. Setze einen sicheren Token als Environment Variable, z. B. in der VirtualHost-/FPM-Konfiguration:
+   ```bash
+   export PMS_UPDATE_SECRET="mein-sicherer-token"
+   ```
+2. Führe das Update per CLI aus:
+   ```bash
+   php backend/update.php mein-sicherer-token
+   ```
+   oder rufe per HTTP `https://dein-host/backend/update.php?token=mein-sicherer-token` auf.
+3. Das Skript führt `git pull` für den aktuellen Branch aus und gibt die Logausgabe als JSON zurück.
+
+> **Hinweis:** Stelle sicher, dass der Webserver-Benutzer die notwendigen Berechtigungen für das Git-Repository besitzt. Andernfalls schlägt das Update fehl.
+
+## Web-Frontend
+
+Neben der reinen API steht jetzt ein leichtgewichtiger Administrations-Client zur Verfügung:
+
+- `public/index.html` bildet ein Single-Page-Dashboard für Reservierungen, Zimmer, Housekeeping, Fakturierung, Berichte, Nutzer und Gäste.
+- Hinterlege den API-Token im Kopfbereich der Anwendung – er wird im Browser-Storage gespeichert.
+- Starte die Oberfläche lokal zum Beispiel mit
+  ```bash
+  php -S 0.0.0.0:8080 -t public
+  ```
+  und rufe anschließend `http://localhost:8080/` im Browser auf. Die API muss parallel (z. B. über Apache/Nginx oder einen zweiten PHP-Built-in-Server) erreichbar sein.
+
+## REST API für den MVP-Funktionsumfang
+
+Nach dem erfolgreichen Datenbank-Setup stellt `backend/api/index.php` eine schlanke REST-API bereit, die sämtliche MVP-Bereiche abdeckt. **Authentifiziere jede Anfrage (außer den Gastportal-Endpoints) mit** `X-API-Key: <API_TOKEN>` oder `?token=`.
+
+### Front-Office & Reservierungen
+- `GET /backend/api/reservations?status=confirmed&from=2024-01-01&to=2024-01-31` – Übersicht über Reservierungen inklusive Zimmerzuweisungen.
+- `POST /backend/api/reservations` – Legt Gäste (falls nötig), Reservierung, Rate-Plan und Zimmerzuweisung in einem Schritt an. Beispiel-Payload:
+  ```json
+  {
+    "guest": {"first_name": "Max", "last_name": "Mustermann", "email": "max@example.com"},
+    "check_in_date": "2024-02-10",
+    "check_out_date": "2024-02-14",
+    "rooms": [{"room_id": 1, "nightly_rate": 120, "currency": "EUR"}],
+    "rate_plan_id": 2,
+    "status": "confirmed",
+    "total_amount": 480,
+    "notes": "Late arrival"
+  }
+  ```
+- `POST /backend/api/reservations/{id}/check-in` bzw. `/check-out` – Walk-in/Walk-out inkl. automatischem Status-Log und Zimmerstatus.
+- `POST /backend/api/reservations/{id}/documents` – Hinterlegt Meldescheine oder andere Dateien (es werden Metadaten gespeichert, die Dateiablage erfolgt extern).
+- `GET|POST|PATCH /backend/api/guests` – Verwalten von Gästestammdaten inklusive optionaler Suchfunktion via `?search=`.
+
+### Housekeeping & Maintenance
+- `GET /backend/api/rooms?status=in_cleaning` – Filterbare Raumliste inkl. Raumtyp.
+- `PATCH /backend/api/rooms/{id}` – Aktualisiert Status (z. B. `available`, `in_cleaning`, `out_of_order`) und protokolliert automatisch einen Housekeeping-Log.
+- `GET|POST|PATCH /backend/api/housekeeping/tasks` – Aufgabenlisten für Reinigung & Technik, inkl. optionaler Raum- und Mitarbeiterzuweisung.
+
+### Fakturierung & Zahlungen
+- `POST /backend/api/invoices` – Erstellt Rechnungen mit beliebig vielen Positionen; Netto-/Steuer-/Brutto-Summen werden automatisch berechnet.
+- `POST /backend/api/payments` – Verbucht Zahlungen (Bar, Karte, externes Gateway) und verknüpft sie mit Rechnungen.
+
+### Berichte & Analytics
+- `GET /backend/api/reports/occupancy?start=2024-02-01&end=2024-02-07` – Tagesbasierte Auslastungsquote.
+- `GET /backend/api/reports/revenue?start=2024-02-01&end=2024-02-29` – Umsatzübersicht inkl. Steuern und Zahlungsarten.
+- `GET /backend/api/reports/forecast` – Einfache Forecast-Kennzahlen auf Basis kommender Reservierungen.
+
+### Nutzer- & Rollenverwaltung
+- `GET|POST /backend/api/users` – Legt Benutzer mit Passwort-Hash an und weist Rollen zu.
+- `GET|POST /backend/api/roles`, `POST /backend/api/roles/{id}/permissions` sowie `GET|POST /backend/api/permissions` – Rollen-/Rechteverwaltung mit Audit-Logs über `reservation_status_logs` bzw. `audit_logs`.
+
+### Integrationen (Platzhalter)
+- `GET /backend/api/integrations` – Liefert den aktuellen Verbindungsstatus zu Channel-Managern, POS, Türschließsystemen und Buchhaltung.
+
+### Gästeportal / Self-Service
+- `GET /backend/api/guest-portal/reservations/{confirmation}` – Gäste sehen Reservierungsdetails, Zimmer und Dokumente.
+- `POST /backend/api/guest-portal/reservations/{confirmation}/check-in` – Self-Check-in; aktualisiert Reservierungs- und Zimmerstatus.
+- `POST /backend/api/guest-portal/reservations/{confirmation}/documents` – Upload von Meldescheinen (Metadaten) durch den Gast.
+- `POST /backend/api/guest-portal/reservations/{confirmation}/upsell` – Gäste buchen Zusatzleistungen, die als `service_orders` im Backoffice landen.
+
+> Tipp: Für lokale Tests bietet sich `php -S 0.0.0.0:8000 -t backend` an. Die API ist dann unter `http://localhost:8000/api/index.php/...` erreichbar.

--- a/backend/api/index.php
+++ b/backend/api/index.php
@@ -1,0 +1,1332 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../bootstrap.php';
+
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+$uri = $_SERVER['REQUEST_URI'] ?? '/';
+$pathInfo = $_SERVER['PATH_INFO'] ?? '';
+if ($pathInfo !== '') {
+    $path = trim($pathInfo, '/');
+} else {
+    $path = parse_url($uri, PHP_URL_PATH) ?? '/';
+    $path = trim($path, '/');
+    $scriptName = trim($_SERVER['SCRIPT_NAME'] ?? '', '/');
+    if ($scriptName !== '' && str_starts_with($path, $scriptName)) {
+        $path = trim(substr($path, strlen($scriptName)), '/');
+    } else {
+        $scriptDir = trim(dirname($_SERVER['SCRIPT_NAME'] ?? ''), '/');
+        if ($scriptDir !== '' && str_starts_with($path, $scriptDir)) {
+            $path = trim(substr($path, strlen($scriptDir)), '/');
+        }
+    }
+}
+$segments = $path === '' ? [] : explode('/', $path);
+$resource = $segments[0] ?? '';
+
+if ($resource === '') {
+    jsonResponse([
+        'name' => 'realPMS Prototype API',
+        'version' => '0.1.0',
+        'resources' => [
+            'room-types',
+            'rate-plans',
+            'rooms',
+            'reservations',
+            'housekeeping/tasks',
+            'invoices',
+            'payments',
+            'reports',
+            'users',
+            'roles',
+            'permissions',
+            'integrations',
+            'guest-portal',
+        ],
+    ]);
+}
+
+$publicResources = ['guest-portal'];
+if (!in_array($resource, $publicResources, true)) {
+    requireApiKey();
+}
+
+switch ($resource) {
+    case 'room-types':
+        handleRoomTypes($method, $segments);
+        break;
+    case 'rate-plans':
+        handleRatePlans($method, $segments);
+        break;
+    case 'rooms':
+        handleRooms($method, $segments);
+        break;
+    case 'reservations':
+        handleReservations($method, $segments);
+        break;
+    case 'guests':
+        handleGuests($method, $segments);
+        break;
+    case 'housekeeping':
+        handleHousekeeping($method, $segments);
+        break;
+    case 'invoices':
+        handleInvoices($method, $segments);
+        break;
+    case 'payments':
+        handlePayments($method, $segments);
+        break;
+    case 'reports':
+        handleReports($method, $segments);
+        break;
+    case 'users':
+        handleUsers($method, $segments);
+        break;
+    case 'roles':
+        handleRoles($method, $segments);
+        break;
+    case 'permissions':
+        handlePermissions($method, $segments);
+        break;
+    case 'integrations':
+        handleIntegrations($method, $segments);
+        break;
+    case 'guest-portal':
+        handleGuestPortal($method, $segments);
+        break;
+    default:
+        jsonResponse(['error' => 'Resource not found.'], 404);
+}
+
+function handleRoomTypes(string $method, array $segments): void
+{
+    $pdo = db();
+    $id = $segments[1] ?? null;
+
+    if ($method === 'GET') {
+        if ($id !== null) {
+            $stmt = $pdo->prepare('SELECT * FROM room_types WHERE id = :id');
+            $stmt->execute(['id' => $id]);
+            $type = $stmt->fetch();
+            if (!$type) {
+                jsonResponse(['error' => 'Room type not found.'], 404);
+            }
+            jsonResponse($type);
+        }
+
+        $stmt = $pdo->query('SELECT * FROM room_types ORDER BY name');
+        jsonResponse($stmt->fetchAll());
+    }
+
+    if ($method === 'POST') {
+        $data = parseJsonBody();
+        if (empty($data['name'])) {
+            jsonResponse(['error' => 'Name is required.'], 422);
+        }
+
+        $stmt = $pdo->prepare('INSERT INTO room_types (name, description, base_occupancy, max_occupancy, base_rate, currency, created_at, updated_at) VALUES (:name, :description, :base_occupancy, :max_occupancy, :base_rate, :currency, :created_at, :updated_at)');
+        $stmt->execute([
+            'name' => $data['name'],
+            'description' => $data['description'] ?? null,
+            'base_occupancy' => $data['base_occupancy'] ?? 1,
+            'max_occupancy' => $data['max_occupancy'] ?? ($data['base_occupancy'] ?? 1),
+            'base_rate' => $data['base_rate'] ?? null,
+            'currency' => $data['currency'] ?? 'EUR',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        jsonResponse(['id' => $pdo->lastInsertId()], 201);
+    }
+
+    if (($method === 'PUT' || $method === 'PATCH') && $id !== null) {
+        $data = parseJsonBody();
+        $fields = ['name', 'description', 'base_occupancy', 'max_occupancy', 'base_rate', 'currency'];
+        $updates = [];
+        $params = ['id' => $id];
+        foreach ($fields as $field) {
+            if (array_key_exists($field, $data)) {
+                $updates[] = sprintf('%s = :%s', $field, $field);
+                $params[$field] = $data[$field];
+            }
+        }
+
+        if (!$updates) {
+            jsonResponse(['error' => 'No changes supplied.'], 422);
+        }
+
+        $updates[] = 'updated_at = :updated_at';
+        $params['updated_at'] = now();
+
+        $stmt = $pdo->prepare(sprintf('UPDATE room_types SET %s WHERE id = :id', implode(', ', $updates)));
+        $stmt->execute($params);
+        jsonResponse(['updated' => true]);
+    }
+
+    jsonResponse(['error' => 'Unsupported method.'], 405);
+}
+
+function handleRatePlans(string $method, array $segments): void
+{
+    $pdo = db();
+    $id = $segments[1] ?? null;
+
+    if ($method === 'GET') {
+        if ($id !== null) {
+            $stmt = $pdo->prepare('SELECT * FROM rate_plans WHERE id = :id');
+            $stmt->execute(['id' => $id]);
+            $plan = $stmt->fetch();
+            if (!$plan) {
+                jsonResponse(['error' => 'Rate plan not found.'], 404);
+            }
+            jsonResponse($plan);
+        }
+
+        $stmt = $pdo->query('SELECT * FROM rate_plans ORDER BY name');
+        jsonResponse($stmt->fetchAll());
+    }
+
+    if ($method === 'POST') {
+        $data = parseJsonBody();
+        if (empty($data['name'])) {
+            jsonResponse(['error' => 'Name is required.'], 422);
+        }
+
+        $stmt = $pdo->prepare('INSERT INTO rate_plans (name, description, base_price, currency, cancellation_policy, created_at, updated_at) VALUES (:name, :description, :base_price, :currency, :cancellation_policy, :created_at, :updated_at)');
+        $stmt->execute([
+            'name' => $data['name'],
+            'description' => $data['description'] ?? null,
+            'base_price' => $data['base_price'] ?? 0,
+            'currency' => $data['currency'] ?? 'EUR',
+            'cancellation_policy' => $data['cancellation_policy'] ?? null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        jsonResponse(['id' => $pdo->lastInsertId()], 201);
+    }
+
+    if (($method === 'PUT' || $method === 'PATCH') && $id !== null) {
+        $data = parseJsonBody();
+        $fields = ['name', 'description', 'base_price', 'currency', 'cancellation_policy'];
+        $updates = [];
+        $params = ['id' => $id];
+        foreach ($fields as $field) {
+            if (array_key_exists($field, $data)) {
+                $updates[] = sprintf('%s = :%s', $field, $field);
+                $params[$field] = $data[$field];
+            }
+        }
+
+        if (!$updates) {
+            jsonResponse(['error' => 'No changes supplied.'], 422);
+        }
+
+        $updates[] = 'updated_at = :updated_at';
+        $params['updated_at'] = now();
+
+        $stmt = $pdo->prepare(sprintf('UPDATE rate_plans SET %s WHERE id = :id', implode(', ', $updates)));
+        $stmt->execute($params);
+        jsonResponse(['updated' => true]);
+    }
+
+    jsonResponse(['error' => 'Unsupported method.'], 405);
+}
+
+function handleRooms(string $method, array $segments): void
+{
+    $pdo = db();
+    $id = $segments[1] ?? null;
+
+    if ($method === 'GET') {
+        if ($id !== null) {
+            $stmt = $pdo->prepare('SELECT rooms.*, room_types.name AS room_type_name FROM rooms JOIN room_types ON rooms.room_type_id = room_types.id WHERE rooms.id = :id');
+            $stmt->execute(['id' => $id]);
+            $room = $stmt->fetch();
+            if (!$room) {
+                jsonResponse(['error' => 'Room not found.'], 404);
+            }
+            jsonResponse($room);
+        }
+
+        $query = 'SELECT rooms.*, room_types.name AS room_type_name FROM rooms JOIN room_types ON rooms.room_type_id = room_types.id';
+        $conditions = [];
+        $params = [];
+        if (isset($_GET['status'])) {
+            $conditions[] = 'rooms.status = :status';
+            $params['status'] = $_GET['status'];
+        }
+        if (isset($_GET['room_type_id'])) {
+            $conditions[] = 'rooms.room_type_id = :room_type_id';
+            $params['room_type_id'] = $_GET['room_type_id'];
+        }
+        if ($conditions) {
+            $query .= ' WHERE ' . implode(' AND ', $conditions);
+        }
+        $query .= ' ORDER BY rooms.room_number';
+
+        $stmt = $pdo->prepare($query);
+        $stmt->execute($params);
+        jsonResponse($stmt->fetchAll());
+    }
+
+    if ($method === 'POST') {
+        $data = parseJsonBody();
+        if (empty($data['room_number']) || empty($data['room_type_id'])) {
+            jsonResponse(['error' => 'room_number and room_type_id are required.'], 422);
+        }
+
+        $stmt = $pdo->prepare('INSERT INTO rooms (room_number, room_type_id, floor, status, notes, created_at, updated_at) VALUES (:room_number, :room_type_id, :floor, :status, :notes, :created_at, :updated_at)');
+        $stmt->execute([
+            'room_number' => $data['room_number'],
+            'room_type_id' => $data['room_type_id'],
+            'floor' => $data['floor'] ?? null,
+            'status' => $data['status'] ?? 'available',
+            'notes' => $data['notes'] ?? null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        jsonResponse(['id' => $pdo->lastInsertId()], 201);
+    }
+
+    if (($method === 'PUT' || $method === 'PATCH') && $id !== null) {
+        $data = parseJsonBody();
+        $fields = ['room_number', 'room_type_id', 'floor', 'status', 'notes'];
+        $updates = [];
+        $params = ['id' => $id];
+        foreach ($fields as $field) {
+            if (array_key_exists($field, $data)) {
+                $updates[] = sprintf('%s = :%s', $field, $field);
+                $params[$field] = $data[$field];
+            }
+        }
+
+        if (!$updates) {
+            jsonResponse(['error' => 'No changes supplied.'], 422);
+        }
+
+        if (isset($data['status'])) {
+            logHousekeepingStatus((int) $id, $data['status'], $data['notes'] ?? null, $data['recorded_by'] ?? null);
+        }
+
+        $updates[] = 'updated_at = :updated_at';
+        $params['updated_at'] = now();
+
+        $stmt = $pdo->prepare(sprintf('UPDATE rooms SET %s WHERE id = :id', implode(', ', $updates)));
+        $stmt->execute($params);
+        jsonResponse(['updated' => true]);
+    }
+
+    jsonResponse(['error' => 'Unsupported method.'], 405);
+}
+
+function handleGuests(string $method, array $segments): void
+{
+    $pdo = db();
+    $id = $segments[1] ?? null;
+
+    if ($method === 'GET') {
+        if ($id !== null) {
+            $stmt = $pdo->prepare('SELECT * FROM guests WHERE id = :id');
+            $stmt->execute(['id' => $id]);
+            $guest = $stmt->fetch();
+            if (!$guest) {
+                jsonResponse(['error' => 'Guest not found.'], 404);
+            }
+            jsonResponse($guest);
+        }
+
+        $query = 'SELECT * FROM guests';
+        $params = [];
+        if (isset($_GET['search']) && $_GET['search'] !== '') {
+            $query .= ' WHERE CONCAT(first_name, " ", last_name) LIKE :search OR email LIKE :search';
+            $params['search'] = '%' . $_GET['search'] . '%';
+        }
+        $query .= ' ORDER BY last_name, first_name';
+        $stmt = $pdo->prepare($query);
+        $stmt->execute($params);
+        jsonResponse($stmt->fetchAll());
+    }
+
+    if ($method === 'POST' && $id === null) {
+        $data = parseJsonBody();
+        foreach (['first_name', 'last_name'] as $field) {
+            if (empty($data[$field])) {
+                jsonResponse(['error' => sprintf('%s is required.', $field)], 422);
+            }
+        }
+
+        $stmt = $pdo->prepare('INSERT INTO guests (first_name, last_name, email, phone, address, city, country, notes, created_at, updated_at) VALUES (:first_name, :last_name, :email, :phone, :address, :city, :country, :notes, :created_at, :updated_at)');
+        $stmt->execute([
+            'first_name' => $data['first_name'],
+            'last_name' => $data['last_name'],
+            'email' => $data['email'] ?? null,
+            'phone' => $data['phone'] ?? null,
+            'address' => $data['address'] ?? null,
+            'city' => $data['city'] ?? null,
+            'country' => $data['country'] ?? null,
+            'notes' => $data['notes'] ?? null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        jsonResponse(['id' => $pdo->lastInsertId()], 201);
+    }
+
+    if (($method === 'PUT' || $method === 'PATCH') && $id !== null) {
+        $data = parseJsonBody();
+        $fields = ['first_name', 'last_name', 'email', 'phone', 'address', 'city', 'country', 'notes'];
+        $updates = [];
+        $params = ['id' => $id];
+        foreach ($fields as $field) {
+            if (array_key_exists($field, $data)) {
+                $updates[] = sprintf('%s = :%s', $field, $field);
+                $params[$field] = $data[$field];
+            }
+        }
+        if (!$updates) {
+            jsonResponse(['error' => 'No changes supplied.'], 422);
+        }
+        $updates[] = 'updated_at = :updated_at';
+        $params['updated_at'] = now();
+        $stmt = $pdo->prepare(sprintf('UPDATE guests SET %s WHERE id = :id', implode(', ', $updates)));
+        $stmt->execute($params);
+        jsonResponse(['updated' => true]);
+    }
+
+    jsonResponse(['error' => 'Unsupported method.'], 405);
+}
+
+function handleReservations(string $method, array $segments): void
+{
+    $pdo = db();
+    $id = $segments[1] ?? null;
+
+    if ($method === 'GET') {
+        if ($id !== null) {
+            $stmt = $pdo->prepare('SELECT r.*, g.first_name, g.last_name, g.email, g.phone FROM reservations r JOIN guests g ON g.id = r.guest_id WHERE r.id = :id');
+            $stmt->execute(['id' => $id]);
+            $reservation = $stmt->fetch();
+            if (!$reservation) {
+                jsonResponse(['error' => 'Reservation not found.'], 404);
+            }
+            $reservation['rooms'] = fetchReservationRooms((int) $id);
+            $reservation['documents'] = fetchReservationDocuments((int) $id);
+            $reservation['status_history'] = fetchReservationStatusLogs((int) $id);
+            jsonResponse($reservation);
+        }
+
+        $conditions = [];
+        $params = [];
+        $query = 'SELECT r.*, g.first_name, g.last_name FROM reservations r JOIN guests g ON g.id = r.guest_id';
+        if (isset($_GET['status'])) {
+            $conditions[] = 'r.status = :status';
+            $params['status'] = $_GET['status'];
+        }
+        if (isset($_GET['from']) && validateDate($_GET['from'])) {
+            $conditions[] = 'r.check_in_date >= :from_date';
+            $params['from_date'] = $_GET['from'];
+        }
+        if (isset($_GET['to']) && validateDate($_GET['to'])) {
+            $conditions[] = 'r.check_out_date <= :to_date';
+            $params['to_date'] = $_GET['to'];
+        }
+        if ($conditions) {
+            $query .= ' WHERE ' . implode(' AND ', $conditions);
+        }
+        $query .= ' ORDER BY r.check_in_date DESC';
+
+        $stmt = $pdo->prepare($query);
+        $stmt->execute($params);
+        $reservations = $stmt->fetchAll();
+        foreach ($reservations as &$reservation) {
+            $reservation['rooms'] = fetchReservationRooms((int) $reservation['id']);
+        }
+        jsonResponse($reservations);
+    }
+
+    if ($method === 'POST' && $id === null) {
+        $data = parseJsonBody();
+        validateReservationPayload($data);
+
+        $pdo->beginTransaction();
+        try {
+            $guestId = $data['guest_id'] ?? null;
+            if ($guestId === null) {
+                $guestId = createGuest($pdo, $data['guest']);
+            }
+
+            $confirmation = $data['confirmation_number'] ?? generateConfirmationNumber();
+            $stmt = $pdo->prepare('INSERT INTO reservations (confirmation_number, guest_id, status, check_in_date, check_out_date, adults, children, rate_plan_id, total_amount, currency, booked_via, notes, created_at, updated_at) VALUES (:confirmation_number, :guest_id, :status, :check_in_date, :check_out_date, :adults, :children, :rate_plan_id, :total_amount, :currency, :booked_via, :notes, :created_at, :updated_at)');
+            $stmt->execute([
+                'confirmation_number' => $confirmation,
+                'guest_id' => $guestId,
+                'status' => $data['status'] ?? 'tentative',
+                'check_in_date' => $data['check_in_date'],
+                'check_out_date' => $data['check_out_date'],
+                'adults' => $data['adults'] ?? 1,
+                'children' => $data['children'] ?? 0,
+                'rate_plan_id' => $data['rate_plan_id'] ?? null,
+                'total_amount' => $data['total_amount'] ?? null,
+                'currency' => $data['currency'] ?? 'EUR',
+                'booked_via' => $data['booked_via'] ?? null,
+                'notes' => $data['notes'] ?? null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            $reservationId = (int) $pdo->lastInsertId();
+            assignRoomsToReservation($pdo, $reservationId, $data['rooms'] ?? [], $data['check_in_date'], $data['check_out_date']);
+            logReservationStatus($pdo, $reservationId, $data['status'] ?? 'tentative', $data['status_notes'] ?? null, $data['recorded_by'] ?? null);
+
+            $pdo->commit();
+            jsonResponse(['id' => $reservationId, 'confirmation_number' => $confirmation], 201);
+        } catch (Throwable $exception) {
+            $pdo->rollBack();
+            jsonResponse(['error' => $exception->getMessage()], 500);
+        }
+    }
+
+    if (($method === 'PUT' || $method === 'PATCH') && $id !== null) {
+        $data = parseJsonBody();
+        $fields = ['status', 'check_in_date', 'check_out_date', 'adults', 'children', 'rate_plan_id', 'total_amount', 'currency', 'booked_via', 'notes'];
+        $updates = [];
+        $params = ['id' => $id];
+        foreach ($fields as $field) {
+            if (array_key_exists($field, $data)) {
+                if (($field === 'check_in_date' || $field === 'check_out_date') && !validateDate($data[$field])) {
+                    jsonResponse(['error' => sprintf('Invalid date for %s', $field)], 422);
+                }
+                $updates[] = sprintf('%s = :%s', $field, $field);
+                $params[$field] = $data[$field];
+            }
+        }
+
+        if (!$updates && empty($data['rooms'])) {
+            jsonResponse(['error' => 'No changes supplied.'], 422);
+        }
+
+        $pdo->beginTransaction();
+        try {
+            if ($updates) {
+                $updates[] = 'updated_at = :updated_at';
+                $params['updated_at'] = now();
+                $stmt = $pdo->prepare(sprintf('UPDATE reservations SET %s WHERE id = :id', implode(', ', $updates)));
+                $stmt->execute($params);
+                if (isset($data['status'])) {
+                    logReservationStatus($pdo, (int) $id, $data['status'], $data['status_notes'] ?? null, $data['recorded_by'] ?? null);
+                }
+            }
+
+            if (!empty($data['rooms'])) {
+                $pdo->prepare('DELETE FROM reservation_rooms WHERE reservation_id = :id')->execute(['id' => $id]);
+                $stmt = $pdo->prepare('SELECT check_in_date, check_out_date FROM reservations WHERE id = :id');
+                $stmt->execute(['id' => $id]);
+                $dates = $stmt->fetch();
+                $checkIn = $data['check_in_date'] ?? $dates['check_in_date'];
+                $checkOut = $data['check_out_date'] ?? $dates['check_out_date'];
+                assignRoomsToReservation($pdo, (int) $id, $data['rooms'], $checkIn, $checkOut);
+            }
+
+            $pdo->commit();
+            jsonResponse(['updated' => true]);
+        } catch (Throwable $exception) {
+            $pdo->rollBack();
+            jsonResponse(['error' => $exception->getMessage()], 500);
+        }
+    }
+
+    if ($method === 'POST' && $id !== null && isset($segments[2])) {
+        $action = $segments[2];
+        if ($action === 'check-in') {
+            $data = parseJsonBody();
+            handleReservationStatusChange((int) $id, 'checked_in', $data);
+        } elseif ($action === 'check-out') {
+            $data = parseJsonBody();
+            handleReservationStatusChange((int) $id, 'checked_out', $data);
+        } elseif ($action === 'documents') {
+            $data = parseJsonBody();
+            addReservationDocument((int) $id, $data);
+        } else {
+            jsonResponse(['error' => 'Unknown reservation action.'], 400);
+        }
+        return;
+    }
+
+    jsonResponse(['error' => 'Unsupported method.'], 405);
+}
+
+function handleReservationStatusChange(int $reservationId, string $status, ?array $payload = null): void
+{
+    $pdo = db();
+    $data = $payload ?? parseJsonBody();
+    $notes = $data['notes'] ?? null;
+    $recordedBy = $data['recorded_by'] ?? null;
+
+    $stmt = $pdo->prepare('UPDATE reservations SET status = :status, updated_at = :updated_at WHERE id = :id');
+    $stmt->execute([
+        'status' => $status,
+        'updated_at' => now(),
+        'id' => $reservationId,
+    ]);
+
+    logReservationStatus($pdo, $reservationId, $status, $notes, $recordedBy);
+
+    if ($status === 'checked_in') {
+        $pdo->prepare("UPDATE rooms SET status = 'occupied', updated_at = :updated_at WHERE id IN (SELECT room_id FROM reservation_rooms WHERE reservation_id = :id)")->execute([
+            'updated_at' => now(),
+            'id' => $reservationId,
+        ]);
+        foreach (getReservationRoomIds($pdo, $reservationId) as $roomId) {
+            logHousekeepingStatus($roomId, 'occupied', $notes, $recordedBy);
+        }
+    }
+
+    if ($status === 'checked_out') {
+        $pdo->prepare("UPDATE rooms SET status = 'in_cleaning', updated_at = :updated_at WHERE id IN (SELECT room_id FROM reservation_rooms WHERE reservation_id = :id)")->execute([
+            'updated_at' => now(),
+            'id' => $reservationId,
+        ]);
+        foreach (getReservationRoomIds($pdo, $reservationId) as $roomId) {
+            logHousekeepingStatus($roomId, 'in_cleaning', $notes, $recordedBy);
+        }
+    }
+
+    jsonResponse(['status' => $status]);
+}
+
+function validateReservationPayload(array $data): void
+{
+    foreach (['check_in_date', 'check_out_date'] as $field) {
+        if (empty($data[$field]) || !validateDate($data[$field])) {
+            jsonResponse(['error' => sprintf('Invalid or missing %s', $field)], 422);
+        }
+    }
+
+    if (!isset($data['guest_id']) && empty($data['guest'])) {
+        jsonResponse(['error' => 'Guest information is required.'], 422);
+    }
+
+    if (isset($data['guest'])) {
+        foreach (['first_name', 'last_name'] as $field) {
+            if (empty($data['guest'][$field])) {
+                jsonResponse(['error' => sprintf('Guest field %s is required.', $field)], 422);
+            }
+        }
+    }
+
+    if (!empty($data['rooms']) && !is_array($data['rooms'])) {
+        jsonResponse(['error' => 'rooms must be an array of room assignments.'], 422);
+    }
+}
+
+function createGuest(PDO $pdo, array $guest): int
+{
+    $stmt = $pdo->prepare('INSERT INTO guests (first_name, last_name, email, phone, address, city, country, notes, created_at, updated_at) VALUES (:first_name, :last_name, :email, :phone, :address, :city, :country, :notes, :created_at, :updated_at)');
+    $stmt->execute([
+        'first_name' => $guest['first_name'],
+        'last_name' => $guest['last_name'],
+        'email' => $guest['email'] ?? null,
+        'phone' => $guest['phone'] ?? null,
+        'address' => $guest['address'] ?? null,
+        'city' => $guest['city'] ?? null,
+        'country' => $guest['country'] ?? null,
+        'notes' => $guest['notes'] ?? null,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    return (int) $pdo->lastInsertId();
+}
+
+function assignRoomsToReservation(PDO $pdo, int $reservationId, array $rooms, string $checkIn, string $checkOut): void
+{
+    foreach ($rooms as $room) {
+        $roomId = is_array($room) ? (int) ($room['room_id'] ?? 0) : (int) $room;
+        if ($roomId === 0) {
+            throw new InvalidArgumentException('room_id is required for each room assignment.');
+        }
+
+        if (!isRoomAvailable($pdo, $roomId, $checkIn, $checkOut, $reservationId)) {
+            throw new RuntimeException(sprintf('Room %d is not available for the selected dates.', $roomId));
+        }
+
+        $nightlyRate = is_array($room) ? ($room['nightly_rate'] ?? null) : null;
+        $currency = is_array($room) ? ($room['currency'] ?? null) : null;
+
+        $stmt = $pdo->prepare('INSERT INTO reservation_rooms (reservation_id, room_id, nightly_rate, currency) VALUES (:reservation_id, :room_id, :nightly_rate, :currency)');
+        $stmt->execute([
+            'reservation_id' => $reservationId,
+            'room_id' => $roomId,
+            'nightly_rate' => $nightlyRate,
+            'currency' => $currency,
+        ]);
+    }
+}
+
+function isRoomAvailable(PDO $pdo, int $roomId, string $checkIn, string $checkOut, ?int $ignoreReservationId = null): bool
+{
+    $query = 'SELECT COUNT(*) FROM reservation_rooms rr JOIN reservations r ON rr.reservation_id = r.id WHERE rr.room_id = :room_id AND r.status NOT IN (\'cancelled\', \'no_show\') AND NOT (r.check_out_date <= :check_in OR r.check_in_date >= :check_out)';
+    $params = [
+        'room_id' => $roomId,
+        'check_in' => $checkIn,
+        'check_out' => $checkOut,
+    ];
+    if ($ignoreReservationId !== null) {
+        $query .= ' AND r.id <> :reservation_id';
+        $params['reservation_id'] = $ignoreReservationId;
+    }
+    $stmt = $pdo->prepare($query);
+    $stmt->execute($params);
+    return (int) $stmt->fetchColumn() === 0;
+}
+
+function fetchReservationRooms(int $reservationId): array
+{
+    $pdo = db();
+    $stmt = $pdo->prepare('SELECT rr.*, rooms.room_number FROM reservation_rooms rr JOIN rooms ON rooms.id = rr.room_id WHERE rr.reservation_id = :id');
+    $stmt->execute(['id' => $reservationId]);
+    return $stmt->fetchAll();
+}
+
+function fetchReservationDocuments(int $reservationId): array
+{
+    $pdo = db();
+    $stmt = $pdo->prepare('SELECT * FROM reservation_documents WHERE reservation_id = :id ORDER BY uploaded_at DESC');
+    $stmt->execute(['id' => $reservationId]);
+    return $stmt->fetchAll();
+}
+
+function fetchReservationStatusLogs(int $reservationId): array
+{
+    $pdo = db();
+    $stmt = $pdo->prepare('SELECT * FROM reservation_status_logs WHERE reservation_id = :id ORDER BY recorded_at DESC');
+    $stmt->execute(['id' => $reservationId]);
+    return $stmt->fetchAll();
+}
+
+function logReservationStatus(PDO $pdo, int $reservationId, string $status, ?string $notes, $recordedBy): void
+{
+    $stmt = $pdo->prepare('INSERT INTO reservation_status_logs (reservation_id, status, notes, recorded_by, recorded_at) VALUES (:reservation_id, :status, :notes, :recorded_by, :recorded_at)');
+    $stmt->execute([
+        'reservation_id' => $reservationId,
+        'status' => $status,
+        'notes' => $notes,
+        'recorded_by' => $recordedBy,
+        'recorded_at' => now(),
+    ]);
+}
+
+function addReservationDocument(int $reservationId, array $data): void
+{
+    if (empty($data['document_type'])) {
+        jsonResponse(['error' => 'document_type is required.'], 422);
+    }
+
+    $pdo = db();
+    $stmt = $pdo->prepare('INSERT INTO reservation_documents (reservation_id, document_type, file_name, file_path, metadata, uploaded_by, uploaded_at) VALUES (:reservation_id, :document_type, :file_name, :file_path, :metadata, :uploaded_by, :uploaded_at)');
+    $stmt->execute([
+        'reservation_id' => $reservationId,
+        'document_type' => $data['document_type'],
+        'file_name' => $data['file_name'] ?? null,
+        'file_path' => $data['file_path'] ?? null,
+        'metadata' => isset($data['metadata']) ? json_encode($data['metadata']) : null,
+        'uploaded_by' => $data['uploaded_by'] ?? null,
+        'uploaded_at' => now(),
+    ]);
+
+    jsonResponse(['created' => true], 201);
+}
+
+function handleHousekeeping(string $method, array $segments): void
+{
+    $sub = $segments[1] ?? null;
+    if ($sub !== 'tasks') {
+        jsonResponse(['error' => 'Unknown housekeeping resource.'], 404);
+    }
+
+    $pdo = db();
+    $id = $segments[2] ?? null;
+
+    if ($method === 'GET') {
+        $query = 'SELECT t.*, rooms.room_number FROM tasks t LEFT JOIN rooms ON rooms.id = t.room_id';
+        $conditions = [];
+        $params = [];
+        if (isset($_GET['status'])) {
+            $conditions[] = 't.status = :status';
+            $params['status'] = $_GET['status'];
+        }
+        if ($conditions) {
+            $query .= ' WHERE ' . implode(' AND ', $conditions);
+        }
+        $query .= ' ORDER BY t.due_date IS NULL, t.due_date';
+
+        $stmt = $pdo->prepare($query);
+        $stmt->execute($params);
+        jsonResponse($stmt->fetchAll());
+    }
+
+    if ($method === 'POST') {
+        $data = parseJsonBody();
+        if (empty($data['title'])) {
+            jsonResponse(['error' => 'title is required.'], 422);
+        }
+
+        $stmt = $pdo->prepare('INSERT INTO tasks (room_id, assigned_to, title, description, status, due_date, created_at, updated_at) VALUES (:room_id, :assigned_to, :title, :description, :status, :due_date, :created_at, :updated_at)');
+        $stmt->execute([
+            'room_id' => $data['room_id'] ?? null,
+            'assigned_to' => $data['assigned_to'] ?? null,
+            'title' => $data['title'],
+            'description' => $data['description'] ?? null,
+            'status' => $data['status'] ?? 'open',
+            'due_date' => isset($data['due_date']) && validateDateTime($data['due_date']) ? $data['due_date'] : null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        jsonResponse(['id' => $pdo->lastInsertId()], 201);
+    }
+
+    if (($method === 'PUT' || $method === 'PATCH') && $id !== null) {
+        $data = parseJsonBody();
+        $fields = ['room_id', 'assigned_to', 'title', 'description', 'status', 'due_date', 'completed_at'];
+        $updates = [];
+        $params = ['id' => $id];
+        foreach ($fields as $field) {
+            if (array_key_exists($field, $data)) {
+                if (in_array($field, ['due_date', 'completed_at'], true) && $data[$field] !== null && !validateDateTime($data[$field])) {
+                    jsonResponse(['error' => sprintf('Invalid datetime for %s', $field)], 422);
+                }
+                $updates[] = sprintf('%s = :%s', $field, $field);
+                $params[$field] = $data[$field];
+            }
+        }
+        if (!$updates) {
+            jsonResponse(['error' => 'No changes supplied.'], 422);
+        }
+        $updates[] = 'updated_at = :updated_at';
+        $params['updated_at'] = now();
+        $stmt = $pdo->prepare(sprintf('UPDATE tasks SET %s WHERE id = :id', implode(', ', $updates)));
+        $stmt->execute($params);
+
+        if (isset($data['room_status']) && isset($data['room_id'])) {
+            logHousekeepingStatus((int) $data['room_id'], $data['room_status'], $data['description'] ?? null, $data['assigned_to'] ?? null);
+        }
+
+        jsonResponse(['updated' => true]);
+    }
+
+    jsonResponse(['error' => 'Unsupported method.'], 405);
+}
+
+function logHousekeepingStatus(int $roomId, string $status, ?string $notes, $userId): void
+{
+    $pdo = db();
+    $stmt = $pdo->prepare('INSERT INTO housekeeping_logs (room_id, status, notes, recorded_by, recorded_at) VALUES (:room_id, :status, :notes, :recorded_by, :recorded_at)');
+    $stmt->execute([
+        'room_id' => $roomId,
+        'status' => $status,
+        'notes' => $notes,
+        'recorded_by' => $userId,
+        'recorded_at' => now(),
+    ]);
+}
+
+function getReservationRoomIds(PDO $pdo, int $reservationId): array
+{
+    $stmt = $pdo->prepare('SELECT room_id FROM reservation_rooms WHERE reservation_id = :reservation_id');
+    $stmt->execute(['reservation_id' => $reservationId]);
+    return array_map('intval', array_column($stmt->fetchAll(), 'room_id'));
+}
+
+function handleInvoices(string $method, array $segments): void
+{
+    $pdo = db();
+    $id = $segments[1] ?? null;
+
+    if ($method === 'GET') {
+        if ($id !== null) {
+            $stmt = $pdo->prepare('SELECT * FROM invoices WHERE id = :id');
+            $stmt->execute(['id' => $id]);
+            $invoice = $stmt->fetch();
+            if (!$invoice) {
+                jsonResponse(['error' => 'Invoice not found.'], 404);
+            }
+            $invoice['items'] = fetchInvoiceItems((int) $id);
+            jsonResponse($invoice);
+        }
+
+        $stmt = $pdo->query('SELECT * FROM invoices ORDER BY issue_date DESC');
+        jsonResponse($stmt->fetchAll());
+    }
+
+    if ($method === 'POST' && $id === null) {
+        $data = parseJsonBody();
+        if (empty($data['reservation_id']) || empty($data['items']) || !is_array($data['items'])) {
+            jsonResponse(['error' => 'reservation_id and items are required.'], 422);
+        }
+
+        $invoiceNumber = $data['invoice_number'] ?? generateInvoiceNumber();
+        $issueDate = $data['issue_date'] ?? date('Y-m-d');
+        $dueDate = $data['due_date'] ?? null;
+        $status = $data['status'] ?? 'issued';
+
+        $totals = calculateInvoiceTotals($data['items']);
+
+        $stmt = $pdo->prepare('INSERT INTO invoices (reservation_id, invoice_number, issue_date, due_date, total_amount, tax_amount, status, created_at, updated_at) VALUES (:reservation_id, :invoice_number, :issue_date, :due_date, :total_amount, :tax_amount, :status, :created_at, :updated_at)');
+        $stmt->execute([
+            'reservation_id' => $data['reservation_id'],
+            'invoice_number' => $invoiceNumber,
+            'issue_date' => $issueDate,
+            'due_date' => $dueDate,
+            'total_amount' => $totals['total'],
+            'tax_amount' => $totals['tax'],
+            'status' => $status,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $invoiceId = (int) $pdo->lastInsertId();
+        storeInvoiceItems($invoiceId, $data['items']);
+
+        jsonResponse(['id' => $invoiceId, 'invoice_number' => $invoiceNumber], 201);
+    }
+
+    jsonResponse(['error' => 'Unsupported method.'], 405);
+}
+
+function fetchInvoiceItems(int $invoiceId): array
+{
+    $pdo = db();
+    $stmt = $pdo->prepare('SELECT * FROM invoice_items WHERE invoice_id = :invoice_id');
+    $stmt->execute(['invoice_id' => $invoiceId]);
+    return $stmt->fetchAll();
+}
+
+function storeInvoiceItems(int $invoiceId, array $items): void
+{
+    $pdo = db();
+    $stmt = $pdo->prepare('INSERT INTO invoice_items (invoice_id, description, quantity, unit_price, tax_rate, total_amount, created_at, updated_at) VALUES (:invoice_id, :description, :quantity, :unit_price, :tax_rate, :total_amount, :created_at, :updated_at)');
+    foreach ($items as $item) {
+        if (empty($item['description'])) {
+            throw new InvalidArgumentException('Each invoice item requires a description.');
+        }
+        $quantity = (float) ($item['quantity'] ?? 1);
+        $unitPrice = (float) ($item['unit_price'] ?? 0);
+        $taxRate = isset($item['tax_rate']) ? (float) $item['tax_rate'] : null;
+        $total = $quantity * $unitPrice * (1 + ($taxRate ?? 0) / 100);
+
+        $stmt->execute([
+            'invoice_id' => $invoiceId,
+            'description' => $item['description'],
+            'quantity' => $quantity,
+            'unit_price' => $unitPrice,
+            'tax_rate' => $taxRate,
+            'total_amount' => $total,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}
+
+function calculateInvoiceTotals(array $items): array
+{
+    $subtotal = 0;
+    $tax = 0;
+    foreach ($items as $item) {
+        $quantity = (float) ($item['quantity'] ?? 1);
+        $unitPrice = (float) ($item['unit_price'] ?? 0);
+        $lineSubtotal = $quantity * $unitPrice;
+        $subtotal += $lineSubtotal;
+        $taxRate = isset($item['tax_rate']) ? (float) $item['tax_rate'] : 0;
+        $tax += $lineSubtotal * ($taxRate / 100);
+    }
+
+    return [
+        'subtotal' => round($subtotal, 2),
+        'tax' => round($tax, 2),
+        'total' => round($subtotal + $tax, 2),
+    ];
+}
+
+function handlePayments(string $method, array $segments): void
+{
+    $pdo = db();
+
+    if ($method === 'GET') {
+        $stmt = $pdo->query('SELECT payments.*, invoices.invoice_number FROM payments JOIN invoices ON invoices.id = payments.invoice_id ORDER BY paid_at DESC');
+        jsonResponse($stmt->fetchAll());
+    }
+
+    if ($method === 'POST') {
+        $data = parseJsonBody();
+        foreach (['invoice_id', 'method', 'amount'] as $field) {
+            if (empty($data[$field])) {
+                jsonResponse(['error' => sprintf('%s is required.', $field)], 422);
+            }
+        }
+
+        $stmt = $pdo->prepare('INSERT INTO payments (invoice_id, method, amount, currency, paid_at, reference, notes, created_at, updated_at) VALUES (:invoice_id, :method, :amount, :currency, :paid_at, :reference, :notes, :created_at, :updated_at)');
+        $stmt->execute([
+            'invoice_id' => $data['invoice_id'],
+            'method' => $data['method'],
+            'amount' => $data['amount'],
+            'currency' => $data['currency'] ?? 'EUR',
+            'paid_at' => $data['paid_at'] ?? now(),
+            'reference' => $data['reference'] ?? null,
+            'notes' => $data['notes'] ?? null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        jsonResponse(['id' => $pdo->lastInsertId()], 201);
+    }
+
+    jsonResponse(['error' => 'Unsupported method.'], 405);
+}
+
+function handleReports(string $method, array $segments): void
+{
+    if ($method !== 'GET') {
+        jsonResponse(['error' => 'Only GET supported for reports.'], 405);
+    }
+
+    $type = $segments[1] ?? null;
+    if ($type === 'occupancy') {
+        $start = $_GET['start'] ?? date('Y-m-d');
+        $end = $_GET['end'] ?? $start;
+        if (!validateDate($start) || !validateDate($end)) {
+            jsonResponse(['error' => 'start and end must be valid dates (Y-m-d).'], 422);
+        }
+        jsonResponse(buildOccupancyReport($start, $end));
+    }
+
+    if ($type === 'revenue') {
+        $start = $_GET['start'] ?? date('Y-m-01');
+        $end = $_GET['end'] ?? date('Y-m-t');
+        if (!validateDate($start) || !validateDate($end)) {
+            jsonResponse(['error' => 'start and end must be valid dates (Y-m-d).'], 422);
+        }
+        jsonResponse(buildRevenueReport($start, $end));
+    }
+
+    if ($type === 'forecast') {
+        $start = $_GET['start'] ?? date('Y-m-d');
+        $end = $_GET['end'] ?? date('Y-m-d', strtotime('+30 days'));
+        if (!validateDate($start) || !validateDate($end)) {
+            jsonResponse(['error' => 'start and end must be valid dates (Y-m-d).'], 422);
+        }
+        jsonResponse(buildForecastReport($start, $end));
+    }
+
+    jsonResponse(['error' => 'Unknown report type.'], 404);
+}
+
+function buildOccupancyReport(string $start, string $end): array
+{
+    $pdo = db();
+    $stmt = $pdo->query('SELECT COUNT(*) FROM rooms');
+    $totalRooms = (int) $stmt->fetchColumn();
+
+    $period = new DatePeriod(new DateTimeImmutable($start), new DateInterval('P1D'), (new DateTimeImmutable($end))->modify('+1 day'));
+    $report = [];
+    foreach ($period as $date) {
+        $formatted = $date->format('Y-m-d');
+        $stmt = $pdo->prepare('SELECT COUNT(DISTINCT rr.room_id) FROM reservation_rooms rr JOIN reservations r ON rr.reservation_id = r.id WHERE r.status IN (\'confirmed\', \'checked_in\') AND :date >= r.check_in_date AND :date < r.check_out_date');
+        $stmt->execute(['date' => $formatted]);
+        $occupied = (int) $stmt->fetchColumn();
+        $report[] = [
+            'date' => $formatted,
+            'occupied_rooms' => $occupied,
+            'available_rooms' => $totalRooms,
+            'occupancy_rate' => $totalRooms === 0 ? 0 : round(($occupied / $totalRooms) * 100, 2),
+        ];
+    }
+
+    return $report;
+}
+
+function buildRevenueReport(string $start, string $end): array
+{
+    $pdo = db();
+    $stmt = $pdo->prepare('SELECT SUM(total_amount) as invoice_total, SUM(tax_amount) as tax_total FROM invoices WHERE issue_date BETWEEN :start AND :end');
+    $stmt->execute(['start' => $start, 'end' => $end]);
+    $invoiceTotals = $stmt->fetch() ?: ['invoice_total' => 0, 'tax_total' => 0];
+
+    $stmt = $pdo->prepare('SELECT method, SUM(amount) as total_amount FROM payments WHERE paid_at BETWEEN :start_dt AND :end_dt GROUP BY method');
+    $stmt->execute([
+        'start_dt' => $start . ' 00:00:00',
+        'end_dt' => $end . ' 23:59:59',
+    ]);
+    $payments = $stmt->fetchAll();
+
+    return [
+        'period' => ['start' => $start, 'end' => $end],
+        'invoices' => $invoiceTotals,
+        'payments' => $payments,
+    ];
+}
+
+function buildForecastReport(string $start, string $end): array
+{
+    $pdo = db();
+    $stmt = $pdo->prepare('SELECT r.check_in_date, r.check_out_date, COUNT(rr.room_id) as rooms, COALESCE(r.total_amount, 0) as total_amount FROM reservations r LEFT JOIN reservation_rooms rr ON rr.reservation_id = r.id WHERE r.status IN (\'tentative\', \'confirmed\') AND r.check_in_date BETWEEN :start AND :end GROUP BY r.id');
+    $stmt->execute(['start' => $start, 'end' => $end]);
+    $rows = $stmt->fetchAll();
+
+    $totalRooms = array_sum(array_column($rows, 'rooms'));
+    $totalRevenue = array_sum(array_column($rows, 'total_amount'));
+
+    return [
+        'period' => ['start' => $start, 'end' => $end],
+        'expected_rooms' => $totalRooms,
+        'expected_revenue' => $totalRevenue,
+        'reservations' => $rows,
+    ];
+}
+
+function handleUsers(string $method, array $segments): void
+{
+    $pdo = db();
+    $id = $segments[1] ?? null;
+
+    if ($method === 'GET') {
+        $stmt = $pdo->query('SELECT u.id, u.name, u.email, u.created_at, u.updated_at FROM users u ORDER BY u.name');
+        $users = $stmt->fetchAll();
+        foreach ($users as &$user) {
+            $stmtRoles = $pdo->prepare('SELECT r.id, r.name FROM roles r JOIN role_user ru ON ru.role_id = r.id WHERE ru.user_id = :user_id');
+            $stmtRoles->execute(['user_id' => $user['id']]);
+            $user['roles'] = $stmtRoles->fetchAll();
+        }
+        jsonResponse($users);
+    }
+
+    if ($method === 'POST' && $id === null) {
+        $data = parseJsonBody();
+        foreach (['name', 'email', 'password'] as $field) {
+            if (empty($data[$field])) {
+                jsonResponse(['error' => sprintf('%s is required.', $field)], 422);
+            }
+        }
+
+        $stmt = $pdo->prepare('INSERT INTO users (name, email, password, created_at, updated_at) VALUES (:name, :email, :password, :created_at, :updated_at)');
+        $stmt->execute([
+            'name' => $data['name'],
+            'email' => $data['email'],
+            'password' => password_hash($data['password'], PASSWORD_BCRYPT),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $userId = (int) $pdo->lastInsertId();
+        if (!empty($data['role_ids']) && is_array($data['role_ids'])) {
+            assignRolesToUser($userId, $data['role_ids']);
+        }
+
+        jsonResponse(['id' => $userId], 201);
+    }
+
+    if ($method === 'POST' && $id !== null && ($segments[2] ?? null) === 'roles') {
+        $data = parseJsonBody();
+        assignRolesToUser((int) $id, $data['role_ids'] ?? []);
+        jsonResponse(['updated' => true]);
+    }
+
+    jsonResponse(['error' => 'Unsupported method.'], 405);
+}
+
+function assignRolesToUser(int $userId, array $roleIds): void
+{
+    $pdo = db();
+    $pdo->prepare('DELETE FROM role_user WHERE user_id = :user_id')->execute(['user_id' => $userId]);
+    $stmt = $pdo->prepare('INSERT INTO role_user (user_id, role_id, assigned_at) VALUES (:user_id, :role_id, :assigned_at)');
+    foreach ($roleIds as $roleId) {
+        $stmt->execute([
+            'user_id' => $userId,
+            'role_id' => $roleId,
+            'assigned_at' => now(),
+        ]);
+    }
+}
+
+function handleRoles(string $method, array $segments): void
+{
+    $pdo = db();
+    $id = $segments[1] ?? null;
+
+    if ($method === 'GET') {
+        $stmt = $pdo->query('SELECT * FROM roles ORDER BY name');
+        jsonResponse($stmt->fetchAll());
+    }
+
+    if ($method === 'POST' && $id === null) {
+        $data = parseJsonBody();
+        if (empty($data['name'])) {
+            jsonResponse(['error' => 'name is required.'], 422);
+        }
+
+        $stmt = $pdo->prepare('INSERT INTO roles (name, description, created_at, updated_at) VALUES (:name, :description, :created_at, :updated_at)');
+        $stmt->execute([
+            'name' => $data['name'],
+            'description' => $data['description'] ?? null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        jsonResponse(['id' => $pdo->lastInsertId()], 201);
+    }
+
+    if ($method === 'POST' && $id !== null && ($segments[2] ?? null) === 'permissions') {
+        $data = parseJsonBody();
+        assignPermissionsToRole((int) $id, $data['permission_ids'] ?? []);
+        jsonResponse(['updated' => true]);
+    }
+
+    jsonResponse(['error' => 'Unsupported method.'], 405);
+}
+
+function assignPermissionsToRole(int $roleId, array $permissionIds): void
+{
+    $pdo = db();
+    $pdo->prepare('DELETE FROM permission_role WHERE role_id = :role_id')->execute(['role_id' => $roleId]);
+    $stmt = $pdo->prepare('INSERT INTO permission_role (permission_id, role_id, granted_at) VALUES (:permission_id, :role_id, :granted_at)');
+    foreach ($permissionIds as $permissionId) {
+        $stmt->execute([
+            'permission_id' => $permissionId,
+            'role_id' => $roleId,
+            'granted_at' => now(),
+        ]);
+    }
+}
+
+function handlePermissions(string $method, array $segments): void
+{
+    $pdo = db();
+
+    if ($method === 'GET') {
+        $stmt = $pdo->query('SELECT * FROM permissions ORDER BY name');
+        jsonResponse($stmt->fetchAll());
+    }
+
+    if ($method === 'POST') {
+        $data = parseJsonBody();
+        if (empty($data['name'])) {
+            jsonResponse(['error' => 'name is required.'], 422);
+        }
+
+        $stmt = $pdo->prepare('INSERT INTO permissions (name, description, created_at, updated_at) VALUES (:name, :description, :created_at, :updated_at)');
+        $stmt->execute([
+            'name' => $data['name'],
+            'description' => $data['description'] ?? null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        jsonResponse(['id' => $pdo->lastInsertId()], 201);
+    }
+
+    jsonResponse(['error' => 'Unsupported method.'], 405);
+}
+
+function handleIntegrations(string $method, array $segments): void
+{
+    if ($method !== 'GET') {
+        jsonResponse(['error' => 'Only GET supported for integrations.'], 405);
+    }
+
+    $type = $segments[1] ?? null;
+    if ($type === null) {
+        jsonResponse([
+            'channel_manager' => ['status' => 'not_connected', 'providers' => ['booking.com', 'expedia']],
+            'door_lock' => ['status' => 'not_configured'],
+            'pos' => ['status' => 'not_configured'],
+            'accounting' => ['status' => 'not_configured'],
+        ]);
+    }
+
+    switch ($type) {
+        case 'channel-manager':
+            jsonResponse(['status' => 'not_connected', 'message' => 'No channel manager connected yet. Configure credentials to enable automatic distribution.']);
+        case 'door-locks':
+            jsonResponse(['status' => 'not_configured', 'message' => 'Door lock integration placeholder.']);
+        case 'pos':
+            jsonResponse(['status' => 'not_configured', 'message' => 'POS integration placeholder.']);
+        case 'accounting':
+            jsonResponse(['status' => 'not_configured', 'message' => 'Accounting export placeholder.']);
+    }
+
+    jsonResponse(['error' => 'Unknown integration.'], 404);
+}
+
+function handleGuestPortal(string $method, array $segments): void
+{
+    $sub = $segments[1] ?? null;
+    if ($sub !== 'reservations') {
+        jsonResponse(['error' => 'Unsupported guest portal resource.'], 404);
+    }
+
+    $confirmation = $segments[2] ?? null;
+    if ($confirmation === null) {
+        jsonResponse(['error' => 'Confirmation number required.'], 422);
+    }
+
+    $pdo = db();
+    $stmt = $pdo->prepare('SELECT r.*, g.first_name, g.last_name, g.email FROM reservations r JOIN guests g ON g.id = r.guest_id WHERE r.confirmation_number = :confirmation');
+    $stmt->execute(['confirmation' => $confirmation]);
+    $reservation = $stmt->fetch();
+    if (!$reservation) {
+        jsonResponse(['error' => 'Reservation not found.'], 404);
+    }
+
+    $action = $segments[3] ?? null;
+    if ($method === 'GET' && $action === null) {
+        $reservation['rooms'] = fetchReservationRooms((int) $reservation['id']);
+        $reservation['documents'] = fetchReservationDocuments((int) $reservation['id']);
+        jsonResponse($reservation);
+    }
+
+    if ($method === 'POST' && $action === 'check-in') {
+        $data = parseJsonBody();
+        $data['notes'] = $data['notes'] ?? 'Guest self check-in';
+        handleReservationStatusChange((int) $reservation['id'], 'checked_in', $data);
+        return;
+    }
+
+    if ($method === 'POST' && $action === 'documents') {
+        $data = parseJsonBody();
+        addReservationDocument((int) $reservation['id'], $data);
+        return;
+    }
+
+    if ($method === 'POST' && $action === 'upsell') {
+        $data = parseJsonBody();
+        if (empty($data['service_type'])) {
+            jsonResponse(['error' => 'service_type is required.'], 422);
+        }
+        $stmt = $pdo->prepare('INSERT INTO service_orders (reservation_id, service_type, status, notes, created_at, updated_at) VALUES (:reservation_id, :service_type, :status, :notes, :created_at, :updated_at)');
+        $stmt->execute([
+            'reservation_id' => $reservation['id'],
+            'service_type' => $data['service_type'],
+            'status' => 'open',
+            'notes' => $data['notes'] ?? null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        jsonResponse(['service_order_id' => $pdo->lastInsertId()], 201);
+        return;
+    }
+
+    jsonResponse(['error' => 'Unsupported guest portal action.'], 405);
+}
+
+function generateConfirmationNumber(): string
+{
+    return strtoupper(bin2hex(random_bytes(4)));
+}
+
+function generateInvoiceNumber(): string
+{
+    return 'INV-' . date('Ymd') . '-' . strtoupper(bin2hex(random_bytes(3)));
+}

--- a/backend/bootstrap.php
+++ b/backend/bootstrap.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+if (!extension_loaded('pdo_mysql')) {
+    http_response_code(500);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => 'PDO MySQL extension is required.']);
+    exit;
+}
+
+/**
+ * Retrieve configuration values merged from env/.env/install config.
+ */
+function config(): array
+{
+    static $config;
+    if ($config !== null) {
+        return $config;
+    }
+
+    $config = [
+        'host' => getEnvValue('DB_HOST', '127.0.0.1'),
+        'port' => getEnvValue('DB_PORT', '3306'),
+        'database' => getEnvValue('DB_DATABASE'),
+        'username' => getEnvValue('DB_USERNAME'),
+        'password' => getEnvValue('DB_PASSWORD'),
+        'api_token' => getEnvValue('API_TOKEN'),
+    ];
+
+    $configPath = __DIR__ . '/../install.config.php';
+    if (file_exists($configPath)) {
+        /** @var array $fileConfig */
+        $fileConfig = require $configPath;
+        $config = array_merge($config, array_filter($fileConfig, static fn ($value) => $value !== null));
+    }
+
+    foreach (['host', 'port', 'database', 'username', 'password'] as $requiredKey) {
+        if (($config[$requiredKey] ?? null) === null || $config[$requiredKey] === '') {
+            throw new RuntimeException(sprintf('Missing configuration for %s', $requiredKey));
+        }
+    }
+
+    return $config;
+}
+
+function getEnvValue(string $key, ?string $default = null): ?string
+{
+    $value = getenv($key);
+    if ($value !== false) {
+        return $value;
+    }
+
+    static $cachedEnv;
+    if ($cachedEnv === null) {
+        $cachedEnv = loadDotEnv(__DIR__ . '/../.env');
+    }
+
+    return $cachedEnv[$key] ?? $default;
+}
+
+function loadDotEnv(string $path): array
+{
+    if (!is_readable($path)) {
+        return [];
+    }
+
+    $values = [];
+    $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    foreach ($lines as $line) {
+        $line = trim($line);
+        if ($line === '' || $line[0] === '#') {
+            continue;
+        }
+
+        [$name, $value] = array_map('trim', explode('=', $line, 2));
+        $values[$name] = trim($value, "'\"");
+    }
+
+    return $values;
+}
+
+function db(): PDO
+{
+    static $pdo;
+    if ($pdo instanceof PDO) {
+        return $pdo;
+    }
+
+    $cfg = config();
+    $dsn = sprintf('mysql:host=%s;port=%s;dbname=%s;charset=utf8mb4', $cfg['host'], $cfg['port'], $cfg['database']);
+    $pdo = new PDO($dsn, $cfg['username'], $cfg['password'], [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ]);
+
+    return $pdo;
+}
+
+function jsonResponse($payload, int $status = 200): void
+{
+    http_response_code($status);
+    header('Content-Type: application/json');
+    echo json_encode($payload, JSON_PRETTY_PRINT);
+    exit;
+}
+
+function parseJsonBody(): array
+{
+    $raw = file_get_contents('php://input');
+    if ($raw === false || $raw === '') {
+        return [];
+    }
+
+    $data = json_decode($raw, true);
+    if (!is_array($data)) {
+        jsonResponse(['error' => 'Invalid JSON body.'], 400);
+    }
+
+    return $data;
+}
+
+function requireApiKey(): void
+{
+    $config = config();
+    $expected = $config['api_token'] ?? null;
+    if ($expected === null || $expected === '') {
+        jsonResponse(['error' => 'API token is not configured. Set API_TOKEN in the environment or install.config.php.'], 500);
+    }
+
+    $provided = null;
+    $headerSource = function_exists('getallheaders') ? getallheaders() : [];
+    $headers = array_change_key_case($headerSource ?: []);
+    if (isset($headers['x-api-key'])) {
+        $provided = $headers['x-api-key'];
+    } elseif (isset($_GET['token'])) {
+        $provided = $_GET['token'];
+    }
+
+    if ($provided === null || !hash_equals($expected, (string) $provided)) {
+        jsonResponse(['error' => 'Unauthorized.'], 401);
+    }
+}
+
+function now(): string
+{
+    return (new DateTimeImmutable('now', new DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+}
+
+function validateDate(string $value): bool
+{
+    return (bool) DateTimeImmutable::createFromFormat('Y-m-d', $value);
+}
+
+function validateDateTime(string $value): bool
+{
+    return (bool) DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $value);
+}

--- a/backend/update.php
+++ b/backend/update.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Lightweight update endpoint to pull the latest changes for the current git branch.
+ *
+ * The script requires a secret token that must be provided either as the first CLI
+ * argument or as a `token` query parameter when called via HTTP. Set the secret
+ * using the `PMS_UPDATE_SECRET` environment variable.
+ */
+
+if (PHP_SAPI === 'cli') {
+    $providedToken = $argv[1] ?? null;
+} else {
+    header('Content-Type: application/json');
+    $providedToken = $_GET['token'] ?? null;
+}
+
+$expectedToken = getenv('PMS_UPDATE_SECRET');
+if ($expectedToken === false || $expectedToken === '') {
+    respond(false, 'Missing PMS_UPDATE_SECRET environment variable. Define it to enable updates.');
+}
+
+if ($providedToken === null || !hash_equals($expectedToken, $providedToken)) {
+    respond(false, 'Invalid or missing update token.', 401);
+}
+
+$repositoryPath = realpath(__DIR__ . '/..');
+if ($repositoryPath === false) {
+    respond(false, 'Unable to resolve repository path.');
+}
+
+$commands = [
+    ['git status --short', 'Repository status'],
+    ['git rev-parse --abbrev-ref HEAD', 'Current branch'],
+];
+
+chdir($repositoryPath);
+
+$branch = null;
+$outputLog = [];
+
+foreach ($commands as [$command, $label]) {
+    [$exitCode, $output] = runCommand($command);
+    $outputLog[] = [$label, $command, $exitCode, $output];
+    if ($exitCode !== 0) {
+        respond(false, sprintf('Command failed: %s', $command), 500, $outputLog);
+    }
+
+    if ($label === 'Current branch') {
+        $branch = trim($output);
+    }
+}
+
+if ($branch === null || $branch === '') {
+    respond(false, 'Could not determine the current branch.', 500, $outputLog);
+}
+
+$pullCommand = sprintf('git pull origin %s', escapeshellarg($branch));
+[$pullExitCode, $pullOutput] = runCommand($pullCommand);
+$outputLog[] = ['Pull latest changes', $pullCommand, $pullExitCode, $pullOutput];
+
+if ($pullExitCode !== 0) {
+    respond(false, 'Update failed. Review the output for details.', 500, $outputLog);
+}
+
+respond(true, 'Repository updated successfully.', 200, $outputLog);
+
+function runCommand(string $command): array
+{
+    $descriptorSpec = [
+        1 => ['pipe', 'w'],
+        2 => ['pipe', 'w'],
+    ];
+
+    $process = proc_open($command, $descriptorSpec, $pipes);
+
+    if (!is_resource($process)) {
+        return [1, 'Could not execute command.'];
+    }
+
+    $stdout = stream_get_contents($pipes[1]);
+    $stderr = stream_get_contents($pipes[2]);
+
+    foreach ($pipes as $pipe) {
+        fclose($pipe);
+    }
+
+    $exitCode = proc_close($process);
+    $output = trim($stdout . ($stderr !== '' ? PHP_EOL . $stderr : ''));
+
+    return [$exitCode, $output];
+}
+
+function respond(bool $success, string $message, int $status = 200, array $log = []): void
+{
+    $payload = [
+        'success' => $success,
+        'message' => $message,
+        'log' => array_map(
+            static fn ($entry) => [
+                'label' => $entry[0] ?? null,
+                'command' => $entry[1] ?? null,
+                'exit_code' => $entry[2] ?? null,
+                'output' => $entry[3] ?? null,
+            ],
+            $log,
+        ),
+    ];
+
+    if (PHP_SAPI === 'cli') {
+        fwrite(STDOUT, json_encode($payload, JSON_PRETTY_PRINT) . PHP_EOL);
+        exit($success ? 0 : 1);
+    }
+
+    http_response_code($status);
+    header('Content-Type: application/json');
+    echo json_encode($payload, JSON_PRETTY_PRINT);
+    exit;
+}

--- a/install.config.php.example
+++ b/install.config.php.example
@@ -1,0 +1,9 @@
+<?php
+return [
+    'host' => '127.0.0.1',
+    'port' => '3306',
+    'database' => 'realpms',
+    'username' => 'realpms_user',
+    'password' => 'secret',
+    'api_token' => 'change-me-api-token',
+];

--- a/install.php
+++ b/install.php
@@ -1,0 +1,416 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Hotel PMS install script.
+ *
+ * This script creates the initial MySQL tables required for the PMS prototype.
+ * It is intentionally framework-agnostic so it can be executed before Laravel
+ * is fully set up.
+ *
+ * Usage (CLI):
+ *   php install.php
+ *
+ * Usage (Browser):
+ *   Place this file on the server and open it. Ensure database credentials are
+ *   configured via environment variables first.
+ */
+
+if (!extension_loaded('pdo_mysql')) {
+    respond('PDO MySQL extension is required. Please enable it before running the installer.', true);
+}
+
+$config = loadConfiguration();
+
+try {
+    $pdo = new PDO(
+        sprintf('mysql:host=%s;port=%s;dbname=%s;charset=utf8mb4', $config['host'], $config['port'], $config['database']),
+        $config['username'],
+        $config['password'],
+        [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        ],
+    );
+} catch (PDOException $exception) {
+    respond('Connection failed: ' . $exception->getMessage(), true);
+}
+
+$statements = getSchemaStatements();
+$results = [];
+
+foreach ($statements as $table => $sql) {
+    try {
+        $pdo->exec($sql);
+        $results[] = sprintf('✓ Created/verified table `%s`', $table);
+    } catch (PDOException $exception) {
+        respond(sprintf('Error creating table %s: %s', $table, $exception->getMessage()), true, $results);
+    }
+}
+
+respond('Installation completed successfully.', false, $results);
+
+/**
+ * Load configuration from environment variables or an optional install config file.
+ */
+function loadConfiguration(): array
+{
+    $config = [
+        'host' => getEnvValue('DB_HOST', '127.0.0.1'),
+        'port' => getEnvValue('DB_PORT', '3306'),
+        'database' => getEnvValue('DB_DATABASE'),
+        'username' => getEnvValue('DB_USERNAME'),
+        'password' => getEnvValue('DB_PASSWORD'),
+    ];
+
+    $configPath = __DIR__ . '/install.config.php';
+    if (file_exists($configPath)) {
+        /** @var array $fileConfig */
+        $fileConfig = require $configPath;
+        $config = array_merge($config, array_filter($fileConfig, static fn ($value) => $value !== null));
+    }
+
+    $requiredKeys = ['host', 'port', 'database', 'username', 'password'];
+    foreach ($requiredKeys as $key) {
+        $value = $config[$key] ?? null;
+        if ($value === null || $value === '') {
+            respond(sprintf('Missing configuration value for %s. Set the corresponding environment variable or update install.config.php.', strtoupper($key)), true);
+        }
+    }
+
+    return $config;
+}
+
+/**
+ * Basic .env style lookup that prefers runtime environment variables.
+ */
+function getEnvValue(string $key, ?string $default = null): ?string
+{
+    if (getenv($key) !== false) {
+        return getenv($key);
+    }
+
+    static $cachedEnv;
+    if ($cachedEnv === null) {
+        $cachedEnv = loadDotEnv(__DIR__ . '/.env');
+    }
+
+    return $cachedEnv[$key] ?? $default;
+}
+
+function loadDotEnv(string $path): array
+{
+    if (!is_readable($path)) {
+        return [];
+    }
+
+    $values = [];
+    $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+
+    foreach ($lines as $line) {
+        $line = trim($line);
+        if ($line === '' || $line[0] === '#') {
+            continue;
+        }
+
+        [$name, $value] = array_map('trim', explode('=', $line, 2));
+        $values[$name] = trim($value, "'\"");
+    }
+
+    return $values;
+}
+
+function getSchemaStatements(): array
+{
+    return [
+        'roles' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS roles (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                name VARCHAR(100) NOT NULL UNIQUE,
+                description VARCHAR(255) NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'permissions' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS permissions (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                name VARCHAR(150) NOT NULL UNIQUE,
+                description VARCHAR(255) NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'users' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS users (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                name VARCHAR(150) NOT NULL,
+                email VARCHAR(150) NOT NULL UNIQUE,
+                password VARCHAR(255) NOT NULL,
+                remember_token VARCHAR(100) NULL,
+                last_login_at TIMESTAMP NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'role_user' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS role_user (
+                user_id BIGINT UNSIGNED NOT NULL,
+                role_id BIGINT UNSIGNED NOT NULL,
+                assigned_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (user_id, role_id),
+                CONSTRAINT fk_role_user_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+                CONSTRAINT fk_role_user_role FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'permission_role' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS permission_role (
+                permission_id BIGINT UNSIGNED NOT NULL,
+                role_id BIGINT UNSIGNED NOT NULL,
+                granted_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (permission_id, role_id),
+                CONSTRAINT fk_permission_role_permission FOREIGN KEY (permission_id) REFERENCES permissions(id) ON DELETE CASCADE,
+                CONSTRAINT fk_permission_role_role FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'guests' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS guests (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                first_name VARCHAR(100) NOT NULL,
+                last_name VARCHAR(100) NOT NULL,
+                email VARCHAR(150) NULL,
+                phone VARCHAR(50) NULL,
+                address VARCHAR(255) NULL,
+                city VARCHAR(100) NULL,
+                country VARCHAR(100) NULL,
+                notes TEXT NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'room_types' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS room_types (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                name VARCHAR(100) NOT NULL,
+                description TEXT NULL,
+                base_occupancy TINYINT UNSIGNED NOT NULL DEFAULT 1,
+                max_occupancy TINYINT UNSIGNED NOT NULL DEFAULT 1,
+                base_rate DECIMAL(10,2) NULL,
+                currency CHAR(3) NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'rooms' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS rooms (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                room_number VARCHAR(50) NOT NULL UNIQUE,
+                room_type_id BIGINT UNSIGNED NOT NULL,
+                floor VARCHAR(50) NULL,
+                status ENUM('available','occupied','out_of_order','in_cleaning') NOT NULL DEFAULT 'available',
+                notes TEXT NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL,
+                CONSTRAINT fk_rooms_room_type FOREIGN KEY (room_type_id) REFERENCES room_types(id)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'rate_plans' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS rate_plans (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                name VARCHAR(100) NOT NULL,
+                description TEXT NULL,
+                base_price DECIMAL(10,2) NOT NULL DEFAULT 0,
+                currency CHAR(3) NOT NULL DEFAULT 'EUR',
+                cancellation_policy TEXT NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'reservations' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS reservations (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                confirmation_number VARCHAR(100) NOT NULL UNIQUE,
+                guest_id BIGINT UNSIGNED NOT NULL,
+                status ENUM('tentative','confirmed','checked_in','checked_out','cancelled','no_show') NOT NULL DEFAULT 'tentative',
+                check_in_date DATE NOT NULL,
+                check_out_date DATE NOT NULL,
+                adults SMALLINT UNSIGNED NOT NULL DEFAULT 1,
+                children SMALLINT UNSIGNED NOT NULL DEFAULT 0,
+                rate_plan_id BIGINT UNSIGNED NULL,
+                total_amount DECIMAL(10,2) NULL,
+                currency CHAR(3) NULL,
+                booked_via VARCHAR(100) NULL,
+                notes TEXT NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL,
+                CONSTRAINT fk_reservations_guest FOREIGN KEY (guest_id) REFERENCES guests(id),
+                CONSTRAINT fk_reservations_rate_plan FOREIGN KEY (rate_plan_id) REFERENCES rate_plans(id)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'reservation_rooms' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS reservation_rooms (
+                reservation_id BIGINT UNSIGNED NOT NULL,
+                room_id BIGINT UNSIGNED NOT NULL,
+                nightly_rate DECIMAL(10,2) NULL,
+                currency CHAR(3) NULL,
+                PRIMARY KEY (reservation_id, room_id),
+                CONSTRAINT fk_reservation_rooms_reservation FOREIGN KEY (reservation_id) REFERENCES reservations(id) ON DELETE CASCADE,
+                CONSTRAINT fk_reservation_rooms_room FOREIGN KEY (room_id) REFERENCES rooms(id)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'invoices' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS invoices (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                reservation_id BIGINT UNSIGNED NOT NULL,
+                invoice_number VARCHAR(100) NOT NULL UNIQUE,
+                issue_date DATE NOT NULL,
+                due_date DATE NULL,
+                total_amount DECIMAL(10,2) NOT NULL,
+                tax_amount DECIMAL(10,2) NULL,
+                status ENUM('draft','issued','paid','void') NOT NULL DEFAULT 'draft',
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL,
+                CONSTRAINT fk_invoices_reservation FOREIGN KEY (reservation_id) REFERENCES reservations(id)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'payments' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS payments (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                invoice_id BIGINT UNSIGNED NOT NULL,
+                method VARCHAR(50) NOT NULL,
+                amount DECIMAL(10,2) NOT NULL,
+                currency CHAR(3) NOT NULL DEFAULT 'EUR',
+                paid_at DATETIME NULL,
+                reference VARCHAR(150) NULL,
+                notes TEXT NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL,
+                CONSTRAINT fk_payments_invoice FOREIGN KEY (invoice_id) REFERENCES invoices(id) ON DELETE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'service_orders' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS service_orders (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                reservation_id BIGINT UNSIGNED NULL,
+                room_id BIGINT UNSIGNED NULL,
+                service_type VARCHAR(100) NOT NULL,
+                status ENUM('open','in_progress','completed','cancelled') NOT NULL DEFAULT 'open',
+                scheduled_at DATETIME NULL,
+                completed_at DATETIME NULL,
+                notes TEXT NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL,
+                CONSTRAINT fk_service_orders_reservation FOREIGN KEY (reservation_id) REFERENCES reservations(id) ON DELETE SET NULL,
+                CONSTRAINT fk_service_orders_room FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE SET NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'invoice_items' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS invoice_items (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                invoice_id BIGINT UNSIGNED NOT NULL,
+                description VARCHAR(255) NOT NULL,
+                quantity DECIMAL(10,2) NOT NULL DEFAULT 1,
+                unit_price DECIMAL(10,2) NOT NULL DEFAULT 0,
+                tax_rate DECIMAL(5,2) NULL,
+                total_amount DECIMAL(10,2) NOT NULL DEFAULT 0,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL,
+                CONSTRAINT fk_invoice_items_invoice FOREIGN KEY (invoice_id) REFERENCES invoices(id) ON DELETE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'reservation_documents' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS reservation_documents (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                reservation_id BIGINT UNSIGNED NOT NULL,
+                document_type VARCHAR(100) NOT NULL,
+                file_name VARCHAR(255) NULL,
+                file_path VARCHAR(255) NULL,
+                metadata JSON NULL,
+                uploaded_by BIGINT UNSIGNED NULL,
+                uploaded_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
+                CONSTRAINT fk_reservation_documents_reservation FOREIGN KEY (reservation_id) REFERENCES reservations(id) ON DELETE CASCADE,
+                CONSTRAINT fk_reservation_documents_user FOREIGN KEY (uploaded_by) REFERENCES users(id) ON DELETE SET NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'reservation_status_logs' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS reservation_status_logs (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                reservation_id BIGINT UNSIGNED NOT NULL,
+                status ENUM('tentative','confirmed','checked_in','checked_out','cancelled','no_show') NOT NULL,
+                notes TEXT NULL,
+                recorded_by BIGINT UNSIGNED NULL,
+                recorded_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
+                CONSTRAINT fk_reservation_status_logs_reservation FOREIGN KEY (reservation_id) REFERENCES reservations(id) ON DELETE CASCADE,
+                CONSTRAINT fk_reservation_status_logs_user FOREIGN KEY (recorded_by) REFERENCES users(id) ON DELETE SET NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'housekeeping_logs' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS housekeeping_logs (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                room_id BIGINT UNSIGNED NOT NULL,
+                status ENUM('clean','dirty','in_progress','out_of_order','available','in_cleaning','occupied','maintenance') NOT NULL,
+                notes TEXT NULL,
+                recorded_by BIGINT UNSIGNED NULL,
+                recorded_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
+                CONSTRAINT fk_housekeeping_logs_room FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE,
+                CONSTRAINT fk_housekeeping_logs_user FOREIGN KEY (recorded_by) REFERENCES users(id) ON DELETE SET NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'tasks' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS tasks (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                room_id BIGINT UNSIGNED NULL,
+                assigned_to BIGINT UNSIGNED NULL,
+                title VARCHAR(150) NOT NULL,
+                description TEXT NULL,
+                status ENUM('open','in_progress','completed','cancelled') NOT NULL DEFAULT 'open',
+                due_date DATETIME NULL,
+                completed_at DATETIME NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL,
+                CONSTRAINT fk_tasks_room FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE SET NULL,
+                CONSTRAINT fk_tasks_user FOREIGN KEY (assigned_to) REFERENCES users(id) ON DELETE SET NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'audit_logs' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS audit_logs (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                user_id BIGINT UNSIGNED NULL,
+                action VARCHAR(150) NOT NULL,
+                auditable_type VARCHAR(150) NOT NULL,
+                auditable_id BIGINT UNSIGNED NULL,
+                changes JSON NULL,
+                ip_address VARCHAR(45) NULL,
+                created_at TIMESTAMP NULL,
+                CONSTRAINT fk_audit_logs_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+    ];
+}
+
+/**
+ * Output helper compatible with CLI or browser execution.
+ */
+function respond(string $message, bool $isError = false, array $log = []): void
+{
+    $status = $isError ? 'error' : 'success';
+    $payload = [
+        'status' => $status,
+        'message' => $message,
+        'steps' => $log,
+    ];
+
+    if (PHP_SAPI === 'cli') {
+        foreach ($log as $line) {
+            echo $line, PHP_EOL;
+        }
+        fwrite($isError ? STDERR : STDOUT, $message . PHP_EOL);
+        exit($isError ? 1 : 0);
+    }
+
+    header('Content-Type: application/json');
+    http_response_code($isError ? 500 : 200);
+    echo json_encode($payload, JSON_PRETTY_PRINT);
+    exit;
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,958 @@
+const API_BASE = '../backend/api/index.php';
+const state = {
+    token: null,
+    roomTypes: [],
+    ratePlans: [],
+    rooms: [],
+    roles: [],
+    loadedSections: new Set(),
+};
+
+const notificationEl = document.getElementById('notification');
+const tokenInput = document.getElementById('api-token');
+const dashboardDateInput = document.getElementById('dashboard-date');
+const reportStartInput = document.getElementById('report-start');
+const reportEndInput = document.getElementById('report-end');
+
+function showMessage(message, type = 'info', timeout = 4000) {
+    if (!notificationEl) {
+        return;
+    }
+    notificationEl.textContent = message;
+    notificationEl.className = `notification show ${type}`;
+    if (timeout) {
+        setTimeout(() => {
+            notificationEl.className = 'notification';
+        }, timeout);
+    }
+}
+
+function requireToken() {
+    if (!state.token) {
+        showMessage('Bitte speichern Sie einen gültigen API-Token, um Daten laden zu können.', 'error');
+        return false;
+    }
+    return true;
+}
+
+async function apiFetch(path, options = {}) {
+    const { skipAuth = false } = options;
+    const normalizedPath = path ? path.replace(/^\/+/, '') : '';
+    const url = normalizedPath ? `${API_BASE}/${normalizedPath}` : API_BASE;
+    const headers = new Headers(options.headers || {});
+    if (!skipAuth) {
+        if (!requireToken()) {
+            throw new Error('Kein API-Token gesetzt.');
+        }
+        headers.set('X-API-Key', state.token);
+    }
+    if (options.body && !headers.has('Content-Type')) {
+        headers.set('Content-Type', 'application/json');
+    }
+
+    const response = await fetch(url, { ...options, headers });
+    if (!response.ok) {
+        let message = `${response.status} ${response.statusText}`;
+        try {
+            const payload = await response.json();
+            if (payload && payload.error) {
+                message = payload.error;
+            }
+        } catch (error) {
+            // ignore json parse errors
+        }
+        throw new Error(message);
+    }
+
+    try {
+        return await response.json();
+    } catch (error) {
+        return null;
+    }
+}
+
+function setToken(token) {
+    state.token = token || null;
+    if (state.token) {
+        localStorage.setItem('realpms_api_token', state.token);
+        showMessage('API-Token gespeichert. Daten werden geladen...', 'success');
+        bootstrap();
+    } else {
+        localStorage.removeItem('realpms_api_token');
+        state.loadedSections.clear();
+        showMessage('API-Token entfernt. Bitte neuen Token speichern.', 'info');
+    }
+}
+
+document.getElementById('token-form').addEventListener('submit', (event) => {
+    event.preventDefault();
+    const token = tokenInput.value.trim();
+    if (!token) {
+        showMessage('Token darf nicht leer sein.', 'error');
+        return;
+    }
+    setToken(token);
+});
+
+document.getElementById('clear-token').addEventListener('click', () => {
+    tokenInput.value = '';
+    setToken(null);
+});
+
+function setDefaultDates() {
+    const today = new Date();
+    const isoToday = today.toISOString().slice(0, 10);
+    if (!dashboardDateInput.value) {
+        dashboardDateInput.value = isoToday;
+    }
+    const monthStart = new Date(today.getFullYear(), today.getMonth(), 1).toISOString().slice(0, 10);
+    if (!reportStartInput.value) {
+        reportStartInput.value = monthStart;
+    }
+    if (!reportEndInput.value) {
+        reportEndInput.value = isoToday;
+    }
+}
+
+function showSection(sectionId) {
+    document.querySelectorAll('.main-nav button').forEach((button) => {
+        button.classList.toggle('active', button.dataset.section === sectionId);
+    });
+    document.querySelectorAll('section[data-section]').forEach((section) => {
+        section.classList.toggle('active', section.id === sectionId);
+    });
+    if (sectionLoaders[sectionId]) {
+        sectionLoaders[sectionId]();
+    }
+}
+
+document.querySelectorAll('.main-nav button').forEach((button) => {
+    button.addEventListener('click', () => showSection(button.dataset.section));
+});
+
+function formatDate(value) {
+    if (!value) {
+        return '';
+    }
+    return new Date(value).toLocaleDateString();
+}
+
+function formatDateTime(value) {
+    if (!value) {
+        return '';
+    }
+    return new Date(value).toLocaleString();
+}
+
+function formatCurrency(amount, currency = 'EUR') {
+    if (amount === null || amount === undefined || amount === '') {
+        return '';
+    }
+    const number = Number(amount);
+    if (Number.isNaN(number)) {
+        return amount;
+    }
+    return new Intl.NumberFormat('de-DE', { style: 'currency', currency }).format(number);
+}
+
+function toSqlDateTime(value) {
+    if (!value) {
+        return null;
+    }
+    if (value.includes('T')) {
+        const [date, time] = value.split('T');
+        const normalizedTime = time.length === 5 ? `${time}:00` : time;
+        return `${date} ${normalizedTime}`;
+    }
+    return value;
+}
+
+function renderTable(containerId, columns, rows, emptyState = 'Keine Daten vorhanden') {
+    const container = document.getElementById(containerId);
+    if (!container) {
+        return;
+    }
+    container.innerHTML = '';
+    if (!rows || rows.length === 0) {
+        const empty = document.createElement('p');
+        empty.className = 'muted';
+        empty.textContent = emptyState;
+        container.appendChild(empty);
+        return;
+    }
+    const table = document.createElement('table');
+    const thead = document.createElement('thead');
+    const headRow = document.createElement('tr');
+    columns.forEach((column) => {
+        const th = document.createElement('th');
+        th.textContent = column.label;
+        headRow.appendChild(th);
+    });
+    thead.appendChild(headRow);
+    table.appendChild(thead);
+    const tbody = document.createElement('tbody');
+    rows.forEach((row) => {
+        const tr = document.createElement('tr');
+        columns.forEach((column) => {
+            const td = document.createElement('td');
+            const value = column.render ? column.render(row) : row[column.key];
+            td.innerHTML = value === undefined || value === null ? '' : value;
+            tr.appendChild(td);
+        });
+        tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+    container.appendChild(table);
+}
+
+async function bootstrap() {
+    if (!requireToken()) {
+        return;
+    }
+    try {
+        const [roomTypes, ratePlans, rooms, roles] = await Promise.all([
+            apiFetch('room-types'),
+            apiFetch('rate-plans'),
+            apiFetch('rooms'),
+            apiFetch('roles'),
+        ]);
+        state.roomTypes = roomTypes;
+        state.ratePlans = ratePlans;
+        state.rooms = rooms;
+        state.roles = roles;
+        populateRoomTypeSelects();
+        populateRatePlanSelect();
+        populateRoomOptions();
+        populateRoleCheckboxes();
+        populateRoomTypeList();
+        populateRatePlanList();
+        state.loadedSections.clear();
+        await Promise.all([
+            loadDashboard(true),
+            loadReservations(true),
+            loadRooms(true),
+            loadHousekeeping(true),
+        ]);
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+function populateRoomTypeSelects() {
+    const roomSelect = document.querySelector('#room-form select[name="room_type"]');
+    if (roomSelect) {
+        roomSelect.innerHTML = state.roomTypes.map((type) => `<option value="${type.id}">${type.name}</option>`).join('');
+    }
+}
+
+function populateRatePlanSelect() {
+    const ratePlanSelect = document.querySelector('#reservation-form select[name="rate_plan"]');
+    if (ratePlanSelect) {
+        const options = state.ratePlans.map((plan) => `<option value="${plan.id}">${plan.name}</option>`);
+        ratePlanSelect.innerHTML = `<option value="">Ohne Rate-Plan</option>${options.join('')}`;
+    }
+}
+
+function populateRoomOptions() {
+    const reservationRoomSelect = document.querySelector('#reservation-form select[name="rooms"]');
+    const taskRoomSelect = document.querySelector('#task-form select[name="room"]');
+    const options = state.rooms.map((room) => `<option value="${room.id}">${room.room_number} (${room.room_type_name})</option>`);
+    if (reservationRoomSelect) {
+        reservationRoomSelect.innerHTML = options.join('');
+    }
+    if (taskRoomSelect) {
+        taskRoomSelect.innerHTML = `<option value="">Kein Zimmer</option>${options.join('')}`;
+    }
+}
+
+function populateRoleCheckboxes() {
+    const container = document.getElementById('user-roles');
+    if (!container) {
+        return;
+    }
+    container.innerHTML = '';
+    state.roles.forEach((role) => {
+        const label = document.createElement('label');
+        const input = document.createElement('input');
+        input.type = 'checkbox';
+        input.value = role.id;
+        label.appendChild(input);
+        label.append(` ${role.name}`);
+        container.appendChild(label);
+    });
+}
+
+function populateRoomTypeList() {
+    renderTable('room-types-list', [
+        { key: 'name', label: 'Name' },
+        { key: 'base_rate', label: 'Grundpreis', render: (row) => formatCurrency(row.base_rate, row.currency || 'EUR') },
+    ], state.roomTypes);
+}
+
+function populateRatePlanList() {
+    renderTable('rate-plans-list', [
+        { key: 'name', label: 'Name' },
+        { key: 'base_price', label: 'Grundpreis', render: (row) => formatCurrency(row.base_price, row.currency || 'EUR') },
+        { key: 'cancellation_policy', label: 'Stornobedingungen' },
+    ], state.ratePlans);
+}
+
+async function loadDashboard(force = false) {
+    if (!requireToken()) {
+        return;
+    }
+    if (!force && state.loadedSections.has('dashboard')) {
+        return;
+    }
+    try {
+        const targetDate = dashboardDateInput.value || new Date().toISOString().slice(0, 10);
+        const startOfMonth = new Date(targetDate);
+        startOfMonth.setDate(1);
+        const monthStart = startOfMonth.toISOString().slice(0, 10);
+        const endOfMonth = new Date(startOfMonth.getFullYear(), startOfMonth.getMonth() + 1, 0).toISOString().slice(0, 10);
+        const [occupancy, revenue, openTasks] = await Promise.all([
+            apiFetch(`reports/occupancy?start=${targetDate}&end=${targetDate}`),
+            apiFetch(`reports/revenue?start=${monthStart}&end=${endOfMonth}`),
+            apiFetch('housekeeping/tasks?status=open'),
+        ]);
+        const occupancyToday = occupancy[0] || null;
+        document.getElementById('dash-occupancy-rate').textContent = occupancyToday ? `${occupancyToday.occupancy_rate}%` : '-- %';
+        document.getElementById('dash-occupancy-detail').textContent = occupancyToday
+            ? `${occupancyToday.occupied_rooms} von ${occupancyToday.available_rooms} Zimmern belegt`
+            : 'Keine Daten';
+        const invoiceTotals = revenue?.invoices || { invoice_total: 0, tax_total: 0 };
+        document.getElementById('dash-revenue-total').textContent = formatCurrency(invoiceTotals.invoice_total || 0);
+        document.getElementById('dash-revenue-detail').textContent = `Steueranteil: ${formatCurrency(invoiceTotals.tax_total || 0)}`;
+        document.getElementById('dash-open-tasks').textContent = openTasks.length;
+        renderTable('occupancy-table', [
+            { key: 'date', label: 'Datum', render: (row) => formatDate(row.date) },
+            { key: 'occupied_rooms', label: 'Belegte Zimmer' },
+            { key: 'available_rooms', label: 'Gesamtzimmer' },
+            { key: 'occupancy_rate', label: 'Auslastung', render: (row) => `${row.occupancy_rate}%` },
+        ], occupancy);
+        state.loadedSections.add('dashboard');
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+async function loadReservations(force = false) {
+    if (!requireToken()) {
+        return;
+    }
+    if (!force && state.loadedSections.has('reservations')) {
+        return;
+    }
+    try {
+        const reservations = await apiFetch('reservations');
+        renderTable('reservations-list', [
+            { key: 'confirmation_number', label: 'Bestätigungsnr.' },
+            { key: 'guest', label: 'Gast', render: (row) => `${row.first_name || ''} ${row.last_name || ''}`.trim() },
+            { key: 'check_in_date', label: 'Check-in', render: (row) => formatDate(row.check_in_date) },
+            { key: 'check_out_date', label: 'Check-out', render: (row) => formatDate(row.check_out_date) },
+            { key: 'status', label: 'Status' },
+            { key: 'rooms', label: 'Zimmer', render: (row) => (row.rooms || []).map((room) => room.room_number).join(', ') },
+            { key: 'total_amount', label: 'Gesamt', render: (row) => formatCurrency(row.total_amount, row.currency || 'EUR') },
+        ], reservations);
+        state.loadedSections.add('reservations');
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+async function loadRooms(force = false) {
+    if (!requireToken()) {
+        return;
+    }
+    if (!force && state.loadedSections.has('rooms')) {
+        return;
+    }
+    try {
+        const rooms = await apiFetch('rooms');
+        state.rooms = rooms;
+        populateRoomOptions();
+        renderTable('rooms-list', [
+            { key: 'room_number', label: 'Zimmer' },
+            { key: 'room_type_name', label: 'Kategorie' },
+            { key: 'floor', label: 'Etage' },
+            { key: 'status', label: 'Status' },
+            { key: 'notes', label: 'Notizen' },
+        ], rooms);
+        state.loadedSections.add('rooms');
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+async function loadHousekeeping(force = false) {
+    if (!requireToken()) {
+        return;
+    }
+    if (!force && state.loadedSections.has('housekeeping')) {
+        return;
+    }
+    try {
+        const tasks = await apiFetch('housekeeping/tasks');
+        renderTable('tasks-list', [
+            { key: 'title', label: 'Titel' },
+            { key: 'room_number', label: 'Zimmer' },
+            { key: 'status', label: 'Status' },
+            { key: 'due_date', label: 'Fällig', render: (row) => formatDateTime(row.due_date) },
+            { key: 'description', label: 'Beschreibung' },
+        ], tasks);
+        state.loadedSections.add('housekeeping');
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+async function loadBilling(force = false) {
+    if (!requireToken()) {
+        return;
+    }
+    if (!force && state.loadedSections.has('billing')) {
+        return;
+    }
+    try {
+        const [invoices, payments] = await Promise.all([
+            apiFetch('invoices'),
+            apiFetch('payments'),
+        ]);
+        renderTable('invoices-list', [
+            { key: 'invoice_number', label: 'Rechnungsnr.' },
+            { key: 'reservation_id', label: 'Reservierung' },
+            { key: 'issue_date', label: 'Ausgestellt am', render: (row) => formatDate(row.issue_date) },
+            { key: 'due_date', label: 'Fällig am', render: (row) => formatDate(row.due_date) },
+            { key: 'status', label: 'Status' },
+            { key: 'total_amount', label: 'Summe', render: (row) => formatCurrency(row.total_amount) },
+        ], invoices);
+        renderTable('payments-list', [
+            { key: 'invoice_number', label: 'Rechnungsnr.' },
+            { key: 'method', label: 'Methode' },
+            { key: 'amount', label: 'Betrag', render: (row) => formatCurrency(row.amount, row.currency || 'EUR') },
+            { key: 'paid_at', label: 'Bezahlt am', render: (row) => formatDateTime(row.paid_at) },
+            { key: 'reference', label: 'Referenz' },
+        ], payments);
+        state.loadedSections.add('billing');
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+async function loadReports(force = false) {
+    if (!requireToken()) {
+        return;
+    }
+    if (!force && state.loadedSections.has('reports')) {
+        return;
+    }
+    try {
+        const start = reportStartInput.value || new Date().toISOString().slice(0, 10);
+        const end = reportEndInput.value || start;
+        const [occupancy, revenue, forecast] = await Promise.all([
+            apiFetch(`reports/occupancy?start=${start}&end=${end}`),
+            apiFetch(`reports/revenue?start=${start}&end=${end}`),
+            apiFetch(`reports/forecast?start=${start}&end=${end}`),
+        ]);
+        renderTable('report-occupancy', [
+            { key: 'date', label: 'Datum', render: (row) => formatDate(row.date) },
+            { key: 'occupied_rooms', label: 'Belegte Zimmer' },
+            { key: 'available_rooms', label: 'Gesamtzimmer' },
+            { key: 'occupancy_rate', label: 'Auslastung', render: (row) => `${row.occupancy_rate}%` },
+        ], occupancy);
+        renderTable('report-revenue', [
+            { key: 'metric', label: 'Kennzahl' },
+            { key: 'value', label: 'Wert' },
+        ], [
+            { metric: 'Rechnungsvolumen', value: formatCurrency(revenue?.invoices?.invoice_total || 0) },
+            { metric: 'Steueranteil', value: formatCurrency(revenue?.invoices?.tax_total || 0) },
+            { metric: 'Zahlungen (Summe)', value: formatCurrency((revenue?.payments || []).reduce((sum, payment) => sum + Number(payment.total_amount || payment.amount || 0), 0)) },
+        ]);
+        renderTable('report-forecast', [
+            { key: 'check_in_date', label: 'Check-in', render: (row) => formatDate(row.check_in_date) },
+            { key: 'check_out_date', label: 'Check-out', render: (row) => formatDate(row.check_out_date) },
+            { key: 'rooms', label: 'Zimmer' },
+            { key: 'total_amount', label: 'Erwarteter Umsatz', render: (row) => formatCurrency(row.total_amount) },
+        ], forecast?.reservations || []);
+        state.loadedSections.add('reports');
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+async function loadUsers(force = false) {
+    if (!requireToken()) {
+        return;
+    }
+    if (!force && state.loadedSections.has('users')) {
+        return;
+    }
+    try {
+        const [users, roles] = await Promise.all([
+            apiFetch('users'),
+            apiFetch('roles'),
+        ]);
+        state.roles = roles;
+        populateRoleCheckboxes();
+        renderTable('users-list', [
+            { key: 'name', label: 'Name' },
+            { key: 'email', label: 'E-Mail' },
+            { key: 'roles', label: 'Rollen', render: (row) => (row.roles || []).map((role) => role.name).join(', ') },
+            { key: 'created_at', label: 'Angelegt am', render: (row) => formatDateTime(row.created_at) },
+        ], users);
+        renderTable('roles-list', [
+            { key: 'name', label: 'Name' },
+            { key: 'description', label: 'Beschreibung' },
+        ], roles);
+        state.loadedSections.add('users');
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+async function loadGuests(force = false) {
+    if (!requireToken()) {
+        return;
+    }
+    if (!force && state.loadedSections.has('guests')) {
+        return;
+    }
+    try {
+        const guests = await apiFetch('guests');
+        renderTable('guests-list', [
+            { key: 'first_name', label: 'Vorname' },
+            { key: 'last_name', label: 'Nachname' },
+            { key: 'email', label: 'E-Mail' },
+            { key: 'phone', label: 'Telefon' },
+            { key: 'notes', label: 'Notizen' },
+        ], guests);
+        state.loadedSections.add('guests');
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+async function loadIntegrations(force = false) {
+    if (!requireToken()) {
+        return;
+    }
+    if (!force && state.loadedSections.has('integrations')) {
+        return;
+    }
+    try {
+        const integrations = await apiFetch('integrations');
+        const container = document.getElementById('integrations-list');
+        container.innerHTML = '';
+        Object.entries(integrations).forEach(([key, value]) => {
+            const card = document.createElement('div');
+            card.className = 'integration-card';
+            card.innerHTML = `<h4>${key.replace(/_/g, ' ').toUpperCase()}</h4><p>Status: <strong>${value.status}</strong></p>${value.message ? `<p class="muted">${value.message}</p>` : ''}`;
+            container.appendChild(card);
+        });
+        state.loadedSections.add('integrations');
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+async function lookupGuestReservation(confirmation) {
+    try {
+        const reservation = await apiFetch(`guest-portal/reservations/${encodeURIComponent(confirmation)}`, { skipAuth: true });
+        renderTable('guest-portal-result', [
+            { key: 'confirmation_number', label: 'Bestätigungsnr.' },
+            { key: 'first_name', label: 'Vorname' },
+            { key: 'last_name', label: 'Nachname' },
+            { key: 'check_in_date', label: 'Check-in', render: (row) => formatDate(row.check_in_date) },
+            { key: 'check_out_date', label: 'Check-out', render: (row) => formatDate(row.check_out_date) },
+            { key: 'status', label: 'Status' },
+        ], reservation ? [reservation] : []);
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+function addInvoiceItemRow() {
+    const container = document.getElementById('invoice-items');
+    const row = document.createElement('div');
+    row.className = 'invoice-item-row';
+    row.innerHTML = `
+        <label>Beschreibung
+            <input type="text" name="description" required>
+        </label>
+        <label>Menge
+            <input type="number" name="quantity" min="0" step="0.01" value="1">
+        </label>
+        <label>Einzelpreis
+            <input type="number" name="unit_price" min="0" step="0.01" value="0">
+        </label>
+        <label>Steuer %
+            <input type="number" name="tax_rate" min="0" step="0.01" value="0">
+        </label>
+        <button type="button" class="secondary remove-item">Entfernen</button>
+    `;
+    row.querySelector('.remove-item').addEventListener('click', () => {
+        row.remove();
+        if (!container.querySelector('.invoice-item-row')) {
+            addInvoiceItemRow();
+        }
+    });
+    container.appendChild(row);
+}
+
+document.getElementById('add-invoice-item').addEventListener('click', (event) => {
+    event.preventDefault();
+    addInvoiceItemRow();
+});
+
+addInvoiceItemRow();
+
+const sectionLoaders = {
+    dashboard: () => loadDashboard(true),
+    reservations: () => loadReservations(true),
+    rooms: () => loadRooms(true),
+    housekeeping: () => loadHousekeeping(true),
+    billing: () => loadBilling(true),
+    reports: () => loadReports(true),
+    users: () => loadUsers(true),
+    guests: () => loadGuests(true),
+    integrations: () => loadIntegrations(true),
+};
+
+// Form submissions
+
+document.getElementById('reservation-form').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!requireToken()) {
+        return;
+    }
+    const form = event.target;
+    const rooms = Array.from(form.rooms.selectedOptions).map((option) => Number(option.value));
+    if (rooms.length === 0) {
+        showMessage('Bitte mindestens ein Zimmer auswählen.', 'error');
+        return;
+    }
+    const payload = {
+        check_in_date: form.check_in.value,
+        check_out_date: form.check_out.value,
+        adults: Number(form.adults.value || 1),
+        children: Number(form.children.value || 0),
+        rate_plan_id: form.rate_plan.value ? Number(form.rate_plan.value) : null,
+        rooms,
+        guest: {
+            first_name: form.guest_first.value,
+            last_name: form.guest_last.value,
+            email: form.guest_email.value || null,
+            phone: form.guest_phone.value || null,
+        },
+        total_amount: form.total_amount.value ? Number(form.total_amount.value) : null,
+        currency: form.currency.value || 'EUR',
+        status: form.status.value,
+        booked_via: form.booked_via.value || null,
+    };
+    try {
+        await apiFetch('reservations', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        });
+        form.reset();
+        populateRatePlanSelect();
+        showMessage('Reservierung wurde angelegt.', 'success');
+        loadReservations(true);
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+});
+
+document.getElementById('reload-reservations').addEventListener('click', () => loadReservations(true));
+document.getElementById('reload-rooms').addEventListener('click', () => loadRooms(true));
+document.getElementById('reload-tasks').addEventListener('click', () => loadHousekeeping(true));
+document.getElementById('reload-invoices').addEventListener('click', () => loadBilling(true));
+document.getElementById('reload-payments').addEventListener('click', () => loadBilling(true));
+document.getElementById('reload-users').addEventListener('click', () => loadUsers(true));
+document.getElementById('reload-guests').addEventListener('click', () => loadGuests(true));
+document.getElementById('reload-integrations').addEventListener('click', () => loadIntegrations(true));
+document.getElementById('refresh-dashboard').addEventListener('click', () => loadDashboard(true));
+document.getElementById('refresh-reports').addEventListener('click', () => loadReports(true));
+
+document.getElementById('room-form').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!requireToken()) {
+        return;
+    }
+    const form = event.target;
+    const payload = {
+        room_number: form.room_number.value,
+        room_type_id: Number(form.room_type.value),
+        floor: form.floor.value || null,
+        status: form.status.value,
+        notes: form.notes.value || null,
+    };
+    try {
+        await apiFetch('rooms', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        });
+        form.reset();
+        showMessage('Zimmer wurde gespeichert.', 'success');
+        loadRooms(true);
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+});
+
+document.getElementById('room-type-form').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!requireToken()) {
+        return;
+    }
+    const form = event.target;
+    const payload = {
+        name: form.name.value,
+        base_rate: form.base_price.value ? Number(form.base_price.value) : null,
+        description: form.description.value || null,
+    };
+    try {
+        await apiFetch('room-types', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        });
+        form.reset();
+        showMessage('Zimmerkategorie erstellt.', 'success');
+        const roomTypes = await apiFetch('room-types');
+        state.roomTypes = roomTypes;
+        populateRoomTypeSelects();
+        populateRoomTypeList();
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+});
+
+document.getElementById('rate-plan-form').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!requireToken()) {
+        return;
+    }
+    const form = event.target;
+    const payload = {
+        name: form.name.value,
+        base_price: form.base_price.value ? Number(form.base_price.value) : null,
+        currency: form.currency.value || 'EUR',
+        cancellation_policy: form.cancellation_policy.value || null,
+    };
+    try {
+        await apiFetch('rate-plans', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        });
+        form.reset();
+        showMessage('Rate-Plan angelegt.', 'success');
+        const ratePlans = await apiFetch('rate-plans');
+        state.ratePlans = ratePlans;
+        populateRatePlanSelect();
+        populateRatePlanList();
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+});
+
+document.getElementById('task-form').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!requireToken()) {
+        return;
+    }
+    const form = event.target;
+    const payload = {
+        room_id: form.room.value ? Number(form.room.value) : null,
+        title: form.title.value,
+        status: form.status.value,
+        due_date: toSqlDateTime(form.due_date.value),
+        description: form.description.value || null,
+    };
+    try {
+        await apiFetch('housekeeping/tasks', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        });
+        form.reset();
+        showMessage('Aufgabe gespeichert.', 'success');
+        loadHousekeeping(true);
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+});
+
+document.getElementById('invoice-form').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!requireToken()) {
+        return;
+    }
+    const form = event.target;
+    const items = Array.from(document.querySelectorAll('#invoice-items .invoice-item-row')).map((row) => {
+        const description = row.querySelector('input[name="description"]').value;
+        if (!description) {
+            return null;
+        }
+        return {
+            description,
+            quantity: Number(row.querySelector('input[name="quantity"]').value || 1),
+            unit_price: Number(row.querySelector('input[name="unit_price"]').value || 0),
+            tax_rate: Number(row.querySelector('input[name="tax_rate"]').value || 0),
+        };
+    }).filter(Boolean);
+    if (items.length === 0) {
+        showMessage('Bitte mindestens eine Rechnungsposition erfassen.', 'error');
+        return;
+    }
+    const payload = {
+        reservation_id: Number(form.reservation_id.value),
+        issue_date: form.issue_date.value || null,
+        due_date: form.due_date.value || null,
+        items,
+    };
+    try {
+        await apiFetch('invoices', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        });
+        form.reset();
+        document.getElementById('invoice-items').innerHTML = '';
+        addInvoiceItemRow();
+        showMessage('Rechnung erstellt.', 'success');
+        loadBilling(true);
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+});
+
+document.getElementById('payment-form').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!requireToken()) {
+        return;
+    }
+    const form = event.target;
+    const payload = {
+        invoice_id: Number(form.invoice_id.value),
+        method: form.method.value,
+        amount: Number(form.amount.value),
+        currency: form.currency.value || 'EUR',
+        paid_at: toSqlDateTime(form.paid_at.value),
+        reference: form.reference.value || null,
+        notes: form.notes.value || null,
+    };
+    try {
+        await apiFetch('payments', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        });
+        form.reset();
+        showMessage('Zahlung erfasst.', 'success');
+        loadBilling(true);
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+});
+
+document.getElementById('user-form').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!requireToken()) {
+        return;
+    }
+    const form = event.target;
+    const roleIds = Array.from(form.querySelectorAll('input[type="checkbox"]:checked')).map((input) => Number(input.value));
+    const payload = {
+        name: form.name.value,
+        email: form.email.value,
+        password: form.password.value,
+        role_ids: roleIds,
+    };
+    try {
+        await apiFetch('users', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        });
+        form.reset();
+        showMessage('Benutzer angelegt.', 'success');
+        loadUsers(true);
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+});
+
+document.getElementById('role-form').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!requireToken()) {
+        return;
+    }
+    const form = event.target;
+    const payload = {
+        name: form.name.value,
+        description: form.description.value || null,
+    };
+    try {
+        await apiFetch('roles', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        });
+        form.reset();
+        showMessage('Rolle erstellt.', 'success');
+        const roles = await apiFetch('roles');
+        state.roles = roles;
+        populateRoleCheckboxes();
+        renderTable('roles-list', [
+            { key: 'name', label: 'Name' },
+            { key: 'description', label: 'Beschreibung' },
+        ], roles);
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+});
+
+document.getElementById('guest-form').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!requireToken()) {
+        return;
+    }
+    const form = event.target;
+    const payload = {
+        first_name: form.first_name.value,
+        last_name: form.last_name.value,
+        email: form.email.value || null,
+        phone: form.phone.value || null,
+        address: form.address.value || null,
+        city: form.city.value || null,
+        country: form.country.value || null,
+        notes: form.notes.value || null,
+    };
+    try {
+        await apiFetch('guests', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        });
+        form.reset();
+        showMessage('Gast gespeichert.', 'success');
+        loadGuests(true);
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+});
+
+document.getElementById('guest-lookup').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const form = event.target;
+    const confirmation = form.confirmation.value.trim();
+    if (!confirmation) {
+        showMessage('Bitte Bestätigungsnummer eingeben.', 'error');
+        return;
+    }
+    await lookupGuestReservation(confirmation);
+});
+
+const storedToken = localStorage.getItem('realpms_api_token');
+if (storedToken) {
+    state.token = storedToken;
+    tokenInput.value = storedToken;
+    bootstrap();
+}
+
+setDefaultDates();
+showSection('dashboard');

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,446 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>realPMS Verwaltung</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<div id="notification" class="notification" role="status" aria-live="polite"></div>
+<header class="top-bar">
+    <div>
+        <h1>realPMS Prototyp</h1>
+        <p class="subtitle">Hotel-PMS Verwaltungsoberfläche</p>
+    </div>
+    <form id="token-form" class="token-form" autocomplete="off">
+        <label for="api-token">API-Token</label>
+        <input id="api-token" name="api-token" type="password" placeholder="Token eingeben" required>
+        <button type="submit">Speichern</button>
+        <button type="button" id="clear-token" class="secondary">Löschen</button>
+    </form>
+</header>
+<nav class="main-nav">
+    <button type="button" data-section="dashboard" class="active">Dashboard</button>
+    <button type="button" data-section="reservations">Reservierungen</button>
+    <button type="button" data-section="rooms">Zimmer</button>
+    <button type="button" data-section="housekeeping">Housekeeping</button>
+    <button type="button" data-section="billing">Fakturierung</button>
+    <button type="button" data-section="reports">Berichte</button>
+    <button type="button" data-section="users">Benutzer</button>
+    <button type="button" data-section="guests">Gäste</button>
+    <button type="button" data-section="integrations">Integrationen</button>
+    <button type="button" data-section="guest-portal">Gästeportal</button>
+</nav>
+<main>
+    <section id="dashboard" data-section class="active">
+        <div class="card-grid">
+            <article class="card">
+                <h2>Heutige Belegung</h2>
+                <p id="dash-occupancy-rate" class="figure">-- %</p>
+                <p id="dash-occupancy-detail" class="muted"></p>
+            </article>
+            <article class="card">
+                <h2>Monatsumsatz</h2>
+                <p id="dash-revenue-total" class="figure">-- EUR</p>
+                <p id="dash-revenue-detail" class="muted"></p>
+            </article>
+            <article class="card">
+                <h2>Offene Aufgaben</h2>
+                <p id="dash-open-tasks" class="figure">--</p>
+                <p class="muted">Housekeeping &amp; Maintenance</p>
+            </article>
+        </div>
+        <div class="panel">
+            <div class="panel-header">
+                <h3>Belegungsübersicht</h3>
+                <div class="panel-actions">
+                    <label for="dashboard-date">Datum</label>
+                    <input type="date" id="dashboard-date">
+                    <button type="button" id="refresh-dashboard" class="secondary">Aktualisieren</button>
+                </div>
+            </div>
+            <div id="occupancy-table" class="table-wrapper"></div>
+        </div>
+    </section>
+
+    <section id="reservations" data-section>
+        <div class="section-header">
+            <h2>Reservierungen</h2>
+            <button type="button" id="reload-reservations" class="secondary">Neu laden</button>
+        </div>
+        <div id="reservations-list" class="table-wrapper"></div>
+        <details class="form-panel">
+            <summary>Neue Reservierung anlegen</summary>
+            <form id="reservation-form" class="grid-form">
+                <fieldset>
+                    <legend>Aufenthalt</legend>
+                    <label>Check-in
+                        <input type="date" name="check_in" required>
+                    </label>
+                    <label>Check-out
+                        <input type="date" name="check_out" required>
+                    </label>
+                    <label>Erwachsene
+                        <input type="number" name="adults" min="1" value="1">
+                    </label>
+                    <label>Kinder
+                        <input type="number" name="children" min="0" value="0">
+                    </label>
+                    <label>Rate-Plan
+                        <select name="rate_plan"></select>
+                    </label>
+                    <label>Zimmer
+                        <select name="rooms" multiple size="4"></select>
+                    </label>
+                </fieldset>
+                <fieldset>
+                    <legend>Gast</legend>
+                    <label>Vorname
+                        <input type="text" name="guest_first" required>
+                    </label>
+                    <label>Nachname
+                        <input type="text" name="guest_last" required>
+                    </label>
+                    <label>E-Mail
+                        <input type="email" name="guest_email">
+                    </label>
+                    <label>Telefon
+                        <input type="tel" name="guest_phone">
+                    </label>
+                </fieldset>
+                <fieldset>
+                    <legend>Abrechnung</legend>
+                    <label>Gesamtbetrag
+                        <input type="number" name="total_amount" min="0" step="0.01">
+                    </label>
+                    <label>Währung
+                        <input type="text" name="currency" value="EUR" maxlength="3">
+                    </label>
+                    <label>Status
+                        <select name="status">
+                            <option value="confirmed">Bestätigt</option>
+                            <option value="tentative">Voranfrage</option>
+                            <option value="checked_in">Eingecheckt</option>
+                        </select>
+                    </label>
+                    <label>Quelle
+                        <input type="text" name="booked_via" placeholder="z.B. Website, Booking.com">
+                    </label>
+                </fieldset>
+                <div class="form-actions">
+                    <button type="submit">Reservierung speichern</button>
+                </div>
+            </form>
+        </details>
+    </section>
+
+    <section id="rooms" data-section>
+        <div class="section-layout">
+            <div class="panel">
+                <div class="panel-header">
+                    <h2>Zimmer</h2>
+                    <button type="button" id="reload-rooms" class="secondary">Neu laden</button>
+                </div>
+                <div id="rooms-list" class="table-wrapper"></div>
+            </div>
+            <div class="panel">
+                <h3>Neues Zimmer</h3>
+                <form id="room-form" class="stacked-form">
+                    <label>Zimmernummer
+                        <input type="text" name="room_number" required>
+                    </label>
+                    <label>Etage
+                        <input type="text" name="floor">
+                    </label>
+                    <label>Zimmerkategorie
+                        <select name="room_type" required></select>
+                    </label>
+                    <label>Status
+                        <select name="status">
+                            <option value="available">Verfügbar</option>
+                            <option value="occupied">Belegt</option>
+                            <option value="dirty">Reinigung erforderlich</option>
+                            <option value="out_of_order">Außer Betrieb</option>
+                        </select>
+                    </label>
+                    <label>Notizen
+                        <textarea name="notes" rows="3"></textarea>
+                    </label>
+                    <button type="submit">Zimmer speichern</button>
+                </form>
+            </div>
+            <div class="panel">
+                <h3>Zimmerkategorie</h3>
+                <form id="room-type-form" class="stacked-form">
+                    <label>Name
+                        <input type="text" name="name" required>
+                    </label>
+                    <label>Grundpreis
+                        <input type="number" name="base_price" min="0" step="0.01">
+                    </label>
+                    <label>Beschreibung
+                        <textarea name="description" rows="3"></textarea>
+                    </label>
+                    <button type="submit">Kategorie anlegen</button>
+                </form>
+                <div id="room-types-list" class="table-wrapper small"></div>
+            </div>
+            <div class="panel">
+                <h3>Rate-Pläne</h3>
+                <form id="rate-plan-form" class="stacked-form">
+                    <label>Name
+                        <input type="text" name="name" required>
+                    </label>
+                    <label>Grundpreis
+                        <input type="number" name="base_price" min="0" step="0.01">
+                    </label>
+                    <label>Währung
+                        <input type="text" name="currency" value="EUR" maxlength="3">
+                    </label>
+                    <label>Stornobedingungen
+                        <textarea name="cancellation_policy" rows="2"></textarea>
+                    </label>
+                    <button type="submit">Rate-Plan erstellen</button>
+                </form>
+                <div id="rate-plans-list" class="table-wrapper small"></div>
+            </div>
+        </div>
+    </section>
+
+    <section id="housekeeping" data-section>
+        <div class="section-header">
+            <h2>Housekeeping &amp; Maintenance</h2>
+            <button type="button" id="reload-tasks" class="secondary">Neu laden</button>
+        </div>
+        <div id="tasks-list" class="table-wrapper"></div>
+        <details class="form-panel">
+            <summary>Neue Aufgabe</summary>
+            <form id="task-form" class="grid-form">
+                <label>Zimmer
+                    <select name="room"></select>
+                </label>
+                <label>Titel
+                    <input type="text" name="title" required>
+                </label>
+                <label>Status
+                    <select name="status">
+                        <option value="open">Offen</option>
+                        <option value="in_progress">In Bearbeitung</option>
+                        <option value="done">Erledigt</option>
+                    </select>
+                </label>
+                <label>Fällig am
+                    <input type="datetime-local" name="due_date">
+                </label>
+                <label>Beschreibung
+                    <textarea name="description" rows="3"></textarea>
+                </label>
+                <button type="submit">Aufgabe speichern</button>
+            </form>
+        </details>
+    </section>
+
+    <section id="billing" data-section>
+        <div class="section-layout">
+            <div class="panel">
+                <div class="panel-header">
+                    <h2>Rechnungen</h2>
+                    <button type="button" id="reload-invoices" class="secondary">Neu laden</button>
+                </div>
+                <div id="invoices-list" class="table-wrapper"></div>
+            </div>
+            <div class="panel">
+                <h3>Neue Rechnung</h3>
+                <form id="invoice-form" class="stacked-form">
+                    <label>Reservierung
+                        <input type="number" name="reservation_id" min="1" required>
+                    </label>
+                    <label>Ausstellungsdatum
+                        <input type="date" name="issue_date">
+                    </label>
+                    <label>Fälligkeitsdatum
+                        <input type="date" name="due_date">
+                    </label>
+                    <div id="invoice-items" class="invoice-items"></div>
+                    <button type="button" id="add-invoice-item" class="secondary">Position hinzufügen</button>
+                    <button type="submit">Rechnung erstellen</button>
+                </form>
+            </div>
+            <div class="panel">
+                <div class="panel-header">
+                    <h2>Zahlungen</h2>
+                    <button type="button" id="reload-payments" class="secondary">Neu laden</button>
+                </div>
+                <div id="payments-list" class="table-wrapper"></div>
+                <form id="payment-form" class="stacked-form">
+                    <h3>Neue Zahlung</h3>
+                    <label>Rechnung
+                        <input type="number" name="invoice_id" min="1" required>
+                    </label>
+                    <label>Methode
+                        <input type="text" name="method" placeholder="z.B. Bar, EC" required>
+                    </label>
+                    <label>Betrag
+                        <input type="number" name="amount" min="0" step="0.01" required>
+                    </label>
+                    <label>Währung
+                        <input type="text" name="currency" value="EUR" maxlength="3">
+                    </label>
+                    <label>Bezahlt am
+                        <input type="datetime-local" name="paid_at">
+                    </label>
+                    <label>Referenz
+                        <input type="text" name="reference">
+                    </label>
+                    <label>Notizen
+                        <textarea name="notes" rows="2"></textarea>
+                    </label>
+                    <button type="submit">Zahlung erfassen</button>
+                </form>
+            </div>
+        </div>
+    </section>
+
+    <section id="reports" data-section>
+        <div class="panel">
+            <div class="panel-header">
+                <h2>Berichte</h2>
+                <div class="panel-actions">
+                    <label>Von
+                        <input type="date" id="report-start">
+                    </label>
+                    <label>Bis
+                        <input type="date" id="report-end">
+                    </label>
+                    <button type="button" id="refresh-reports" class="secondary">Aktualisieren</button>
+                </div>
+            </div>
+            <div class="report-grid">
+                <div>
+                    <h3>Belegung</h3>
+                    <div id="report-occupancy" class="table-wrapper"></div>
+                </div>
+                <div>
+                    <h3>Umsatz</h3>
+                    <div id="report-revenue" class="table-wrapper"></div>
+                </div>
+                <div>
+                    <h3>Forecast</h3>
+                    <div id="report-forecast" class="table-wrapper"></div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="users" data-section>
+        <div class="section-layout">
+            <div class="panel">
+                <div class="panel-header">
+                    <h2>Benutzer</h2>
+                    <button type="button" id="reload-users" class="secondary">Neu laden</button>
+                </div>
+                <div id="users-list" class="table-wrapper"></div>
+            </div>
+            <div class="panel">
+                <h3>Benutzer anlegen</h3>
+                <form id="user-form" class="stacked-form">
+                    <label>Name
+                        <input type="text" name="name" required>
+                    </label>
+                    <label>E-Mail
+                        <input type="email" name="email" required>
+                    </label>
+                    <label>Passwort
+                        <input type="password" name="password" required>
+                    </label>
+                    <fieldset>
+                        <legend>Rollen</legend>
+                        <div id="user-roles" class="checkbox-grid"></div>
+                    </fieldset>
+                    <button type="submit">Benutzer speichern</button>
+                </form>
+            </div>
+            <div class="panel">
+                <h3>Rollenverwaltung</h3>
+                <form id="role-form" class="stacked-form">
+                    <label>Name
+                        <input type="text" name="name" required>
+                    </label>
+                    <label>Beschreibung
+                        <textarea name="description" rows="2"></textarea>
+                    </label>
+                    <button type="submit">Rolle erstellen</button>
+                </form>
+                <div id="roles-list" class="table-wrapper small"></div>
+            </div>
+        </div>
+    </section>
+
+    <section id="guests" data-section>
+        <div class="section-header">
+            <h2>Gäste</h2>
+            <button type="button" id="reload-guests" class="secondary">Neu laden</button>
+        </div>
+        <div id="guests-list" class="table-wrapper"></div>
+        <details class="form-panel">
+            <summary>Gast anlegen</summary>
+            <form id="guest-form" class="grid-form">
+                <label>Vorname
+                    <input type="text" name="first_name" required>
+                </label>
+                <label>Nachname
+                    <input type="text" name="last_name" required>
+                </label>
+                <label>E-Mail
+                    <input type="email" name="email">
+                </label>
+                <label>Telefon
+                    <input type="tel" name="phone">
+                </label>
+                <label>Adresse
+                    <input type="text" name="address">
+                </label>
+                <label>Stadt
+                    <input type="text" name="city">
+                </label>
+                <label>Land
+                    <input type="text" name="country">
+                </label>
+                <label>Notizen
+                    <textarea name="notes" rows="3"></textarea>
+                </label>
+                <button type="submit">Gast speichern</button>
+            </form>
+        </details>
+    </section>
+
+    <section id="integrations" data-section>
+        <div class="panel">
+            <div class="panel-header">
+                <h2>Integrationsstatus</h2>
+                <button type="button" id="reload-integrations" class="secondary">Neu laden</button>
+            </div>
+            <div id="integrations-list" class="integration-grid"></div>
+        </div>
+    </section>
+
+    <section id="guest-portal" data-section>
+        <div class="panel">
+            <h2>Gästeportal Vorschau</h2>
+            <form id="guest-lookup" class="inline-form">
+                <label>Bestätigungsnummer
+                    <input type="text" name="confirmation" required>
+                </label>
+                <button type="submit">Reservierung anzeigen</button>
+            </form>
+            <div id="guest-portal-result" class="table-wrapper"></div>
+        </div>
+    </section>
+</main>
+<footer class="app-footer">
+    <p>realPMS Prototype &mdash; Demonstrationsoberfläche</p>
+</footer>
+<script src="app.js" type="module"></script>
+</body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,388 @@
+:root {
+    color-scheme: light dark;
+    --bg: #f6f7fb;
+    --surface: #ffffff;
+    --surface-alt: #f0f2f9;
+    --primary: #2563eb;
+    --primary-dark: #1d4ed8;
+    --text: #1f2937;
+    --muted: #6b7280;
+    --border: #d1d5db;
+    font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+}
+
+body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.top-bar {
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    padding: 1rem 2rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 2rem;
+}
+
+.subtitle {
+    margin: 0;
+    color: var(--muted);
+}
+
+.token-form {
+    display: flex;
+    gap: .75rem;
+    align-items: center;
+}
+
+.token-form input {
+    padding: .5rem .75rem;
+    border-radius: .5rem;
+    border: 1px solid var(--border);
+    min-width: 14rem;
+}
+
+button {
+    cursor: pointer;
+    border: none;
+    border-radius: .5rem;
+    padding: .6rem 1.1rem;
+    background: var(--primary);
+    color: white;
+    font-weight: 600;
+    transition: background .2s ease-in-out;
+}
+
+button.secondary {
+    background: var(--surface-alt);
+    color: var(--text);
+    border: 1px solid var(--border);
+}
+
+button:hover {
+    background: var(--primary-dark);
+}
+
+button.secondary:hover {
+    background: var(--border);
+}
+
+.main-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .75rem;
+    padding: 1rem 2rem;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+}
+
+.main-nav button {
+    background: transparent;
+    color: var(--muted);
+    border: none;
+    padding: .35rem 0;
+    position: relative;
+}
+
+.main-nav button::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: -.75rem;
+    width: 100%;
+    height: 3px;
+    background: transparent;
+    border-radius: 999px;
+    transition: background .2s ease-in-out;
+}
+
+.main-nav button.active {
+    color: var(--primary);
+    font-weight: 600;
+}
+
+.main-nav button.active::after {
+    background: var(--primary);
+}
+
+main {
+    flex: 1;
+    padding: 2rem;
+    display: grid;
+}
+
+section[data-section] {
+    display: none;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+section[data-section].active {
+    display: flex;
+}
+
+.card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+}
+
+.card {
+    background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
+    color: #ffffff;
+    border-radius: 1rem;
+    padding: 1.5rem;
+    box-shadow: 0 10px 25px rgba(37, 99, 235, 0.2);
+}
+
+.card .figure {
+    font-size: 2.2rem;
+    margin: .5rem 0;
+}
+
+.card .muted {
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.panel {
+    background: var(--surface);
+    border-radius: 1rem;
+    box-shadow: 0 10px 25px rgba(15, 23, 42, 0.05);
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.panel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.panel-actions {
+    display: flex;
+    gap: .75rem;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+.section-layout {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+}
+
+.table-wrapper {
+    overflow-x: auto;
+}
+
+.table-wrapper table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 400px;
+}
+
+.table-wrapper th,
+.table-wrapper td {
+    text-align: left;
+    padding: .65rem .75rem;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+}
+
+.table-wrapper tbody tr:hover {
+    background: var(--surface-alt);
+}
+
+.form-panel {
+    background: var(--surface);
+    border-radius: 1rem;
+    box-shadow: 0 10px 25px rgba(15, 23, 42, 0.05);
+    padding: 1rem 1.5rem;
+}
+
+.form-panel summary {
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.grid-form {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem 1.5rem;
+}
+
+.grid-form fieldset {
+    border: 1px solid var(--border);
+    border-radius: .75rem;
+    padding: 1rem;
+    display: grid;
+    gap: .75rem;
+}
+
+.grid-form legend {
+    font-weight: 600;
+    padding: 0 .35rem;
+}
+
+.grid-form label,
+.stacked-form label {
+    display: flex;
+    flex-direction: column;
+    gap: .4rem;
+    font-size: .95rem;
+}
+
+input, select, textarea {
+    border: 1px solid var(--border);
+    border-radius: .5rem;
+    padding: .55rem .7rem;
+    font: inherit;
+    background: #fff;
+}
+
+textarea {
+    resize: vertical;
+}
+
+.form-actions {
+    grid-column: 1 / -1;
+    display: flex;
+    justify-content: flex-end;
+}
+
+.stacked-form {
+    display: grid;
+    gap: 1rem;
+}
+
+.checkbox-grid {
+    display: grid;
+    gap: .5rem;
+}
+
+.checkbox-grid label {
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+    font-weight: 500;
+}
+
+.invoice-items {
+    display: grid;
+    gap: .75rem;
+}
+
+.invoice-item-row {
+    display: grid;
+    grid-template-columns: 1.5fr repeat(3, minmax(80px, 1fr));
+    gap: .5rem;
+    align-items: end;
+}
+
+.invoice-item-row label {
+    display: flex;
+    flex-direction: column;
+    gap: .25rem;
+    font-size: .9rem;
+}
+
+.inline-form {
+    display: flex;
+    gap: 1rem;
+    align-items: flex-end;
+    flex-wrap: wrap;
+}
+
+.integration-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+}
+
+.integration-card {
+    border: 1px solid var(--border);
+    border-radius: .75rem;
+    padding: 1rem;
+    background: var(--surface-alt);
+}
+
+.notification {
+    position: fixed;
+    top: 1rem;
+    right: 1rem;
+    padding: 1rem 1.25rem;
+    border-radius: .75rem;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    box-shadow: 0 10px 25px rgba(15, 23, 42, 0.15);
+    min-width: 220px;
+    z-index: 1000;
+    display: none;
+}
+
+.notification.show {
+    display: block;
+}
+
+.notification.success {
+    border-color: #16a34a;
+    color: #166534;
+}
+
+.notification.error {
+    border-color: #dc2626;
+    color: #991b1b;
+}
+
+.notification.info {
+    border-color: var(--primary);
+    color: var(--primary-dark);
+}
+
+.report-grid {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.muted {
+    color: var(--muted);
+}
+
+.app-footer {
+    padding: 1rem 2rem;
+    text-align: center;
+    color: var(--muted);
+}
+
+@media (max-width: 720px) {
+    .top-bar {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .token-form {
+        width: 100%;
+        flex-wrap: wrap;
+    }
+
+    .invoice-item-row {
+        grid-template-columns: 1fr;
+    }
+}


### PR DESCRIPTION
## Summary
- add a browser-based admin dashboard SPA covering reservations, rooms, housekeeping, billing, reports, users, guests, integrations, and guest portal preview
- expose guest management endpoints and document how to run the new frontend alongside the existing REST API

## Testing
- php -l backend/api/index.php

------
https://chatgpt.com/codex/tasks/task_e_68ef7477204c833396f1c87cd8c9239d