### PR TITLE
Implement invoice cart management and invoice closing

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Nach dem erfolgreichen Datenbank-Setup stellt `backend/api/index.php` eine schla
 
 ### Fakturierung & Zahlungen
 - `POST /backend/api/invoices` – Erstellt Rechnungen mit beliebig vielen Positionen; Netto-/Steuer-/Brutto-Summen werden automatisch berechnet. Ohne eigene Nummer erhält jede neue Rechnung automatisch die nächste Sequenz (`INV-000001`, `INV-000002`, …). Mit `type: "correction"` plus `parent_invoice_id` erzeugst du Rechnungskorrekturen inklusive fortlaufender `correction_number` (`COR-000001`, …); Positionen der Ursprungrechnung werden dabei mit negativen Mengen übernommen.
+- `GET|POST|PATCH|DELETE /backend/api/invoice-carts/{reservationId}` – Pflegt den Warenkorb einer Reservierung, um Positionen gezielt für Teilrechnungen auszuwählen. Einzelne Posten lassen sich hinzufügen, aktualisieren oder löschen; beim Fakturieren werden sie automatisch als abgerechnet markiert.
+- `POST /backend/api/invoices/{id}/close` – Schließt eine Rechnung mit aktuellem Zeitstempel endgültig ab. Änderungen sind danach nur noch über Rechnungskorrekturen möglich.
 - `POST /backend/api/payments` – Verbucht Zahlungen (Bar, Karte, externes Gateway) und verknüpft sie mit Rechnungen.
 - `GET /backend/api/invoices/{id}/pdf` – Rendert die Rechnung als PDF (inkl. Rechnungslogo, Netto-/MwSt.-Ausweis und Artikellisten) über die mitgelieferte FPDF-Library.
   - **Wichtig:** Lade die Standard-Schriftdateien der FPDF-Library (z. B. `helvetica.php`, `courier.php`) manuell in `backend/lib/font/` hoch; sie sind aus lizenzrechtlichen Gründen nicht im Repository enthalten.

--- a/public/index.html
+++ b/public/index.html
@@ -96,8 +96,40 @@
                             <a id="reservation-invoice-link" class="meta-link hidden" href="#" target="_blank" rel="noopener">PDF öffnen</a>
                             <button type="button" id="reservation-create-invoice">Rechnung erstellen</button>
                             <button type="button" id="reservation-pay-invoice" class="secondary">Als bezahlt verbuchen</button>
+                            <button type="button" id="reservation-close-invoice" class="secondary">Rechnung abschließen</button>
                         </div>
                         <p id="reservation-invoice-status" class="muted small-text"></p>
+                    </div>
+                    <div class="reservation-meta-block">
+                        <span class="meta-label">Warenkorb</span>
+                        <div class="meta-actions">
+                            <button type="button" id="reservation-cart-add" class="secondary">Position hinzufügen</button>
+                            <button type="button" id="reservation-cart-refresh" class="secondary">Aktualisieren</button>
+                        </div>
+                        <ul id="reservation-cart-items" class="meta-list"></ul>
+                        <p id="reservation-cart-total" class="muted small-text"></p>
+                        <form id="reservation-cart-form" class="cart-form hidden">
+                            <div class="cart-form-row">
+                                <label>Beschreibung
+                                    <input type="text" name="description" required>
+                                </label>
+                            </div>
+                            <div class="cart-form-grid">
+                                <label>Menge
+                                    <input type="number" name="quantity" step="0.01" min="0.01" value="1">
+                                </label>
+                                <label>Einzelpreis
+                                    <input type="number" name="unit_price" step="0.01" value="0">
+                                </label>
+                                <label>MwSt %
+                                    <input type="number" name="tax_rate" step="0.01" value="7">
+                                </label>
+                            </div>
+                            <div class="cart-form-actions">
+                                <button type="submit">Speichern</button>
+                                <button type="button" id="reservation-cart-cancel" class="secondary">Abbrechen</button>
+                            </div>
+                        </form>
                     </div>
                 </div>
                 <fieldset>

--- a/public/styles.css
+++ b/public/styles.css
@@ -464,6 +464,74 @@ button.status-action:disabled:hover {
     min-width: 220px;
 }
 
+.meta-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: .35rem;
+}
+
+.meta-list li {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: .5rem;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: .6rem;
+    padding: .4rem .65rem;
+}
+
+.meta-list li.meta-list-empty {
+    background: none;
+    border: none;
+    padding: 0;
+    justify-content: flex-start;
+}
+
+.meta-list label {
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+    flex: 1;
+}
+
+.meta-list input[type="checkbox"] {
+    accent-color: var(--primary);
+}
+
+.cart-form {
+    display: flex;
+    flex-direction: column;
+    gap: .75rem;
+    padding: .75rem;
+    border: 1px solid var(--border);
+    border-radius: .75rem;
+    background: var(--surface);
+}
+
+.cart-form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: .75rem;
+}
+
+.cart-form-grid label,
+.cart-form-row label {
+    display: flex;
+    flex-direction: column;
+    gap: .35rem;
+}
+
+.cart-form-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .5rem;
+    justify-content: flex-end;
+}
+
 .meta-label {
     font-size: .75rem;
     font-weight: 600;


### PR DESCRIPTION
## Summary
- add database schema and API endpoints for reservation invoice carts to support split billing
- add invoice closing endpoint with automatic timestamping and enforce corrections for changes
- update reservation UI to manage cart items, close invoices, and document the new workflow

## Testing
- php -l backend/api/index.php
- node --check public/app.js

------
https://chatgpt.com/codex/tasks/task_e_68f0889cc2748333bc86b6566ecb64ac