### PR TITLE
Remove unused rate plan select setup from reservation UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,133 @@
 # realPMS
-Ein wunderschönes PMS
+
+Ein wunderschönes PMS – jetzt mit ersten Setup-Skripten.
+
+## Installation der Datenbanktabellen
+
+1. Erstelle eine `.env` oder `install.config.php` Datei mit den MySQL-Zugangsdaten **und** einem API-Token:
+   ```ini
+   DB_HOST=127.0.0.1
+   DB_PORT=3306
+   DB_DATABASE=realpms
+   DB_USERNAME=realpms_user
+   DB_PASSWORD=geheimespasswort
+    API_TOKEN=mein-ultra-sicheres-token
+   ```
+   Alternativ kannst du `install.config.php` auf Basis von `install.config.php.example` anpassen.
+2. Führe den Installer per CLI aus:
+   ```bash
+   php install.php
+   ```
+   oder rufe `install.php` im Browser auf. Die Skriptausgabe bestätigt die Erstellung aller Tabellen.
+
+> **Hinweis:** Stelle sicher, dass der Webserver Schreibrechte auf `backend/storage` besitzt – hier landen u. a. das Rechnungslogo
+und temporäre PDF-Dateien.
+
+## Repository-Update über das Backend
+
+Für ein automatisiertes Update des aktuell ausgecheckten Branches steht `backend/update.php` bereit.
+
+1. Setze einen sicheren Token als Environment Variable, z. B. in der VirtualHost-/FPM-Konfiguration:
+   ```bash
+   export PMS_UPDATE_SECRET="mein-sicherer-token"
+   ```
+2. Führe das Update per CLI aus:
+   ```bash
+   php backend/update.php mein-sicherer-token
+   ```
+   oder rufe per HTTP `https://dein-host/backend/update.php?token=mein-sicherer-token` auf.
+3. Das Skript führt `git pull` für den aktuellen Branch aus und gibt die Logausgabe als JSON zurück.
+4. Falls Git auf dem Webserver nicht verfügbar ist, lädt das Skript automatisch ein ZIP-Archiv von GitHub:
+   - Standardmäßig wird `https://github.com/rinkelzz/realpms` mit dem Branch `main` verwendet.
+   - Über Umgebungsvariablen kannst du die Quelle anpassen:
+     - `PMS_UPDATE_REPO_SLUG` (z. B. `meinkonto/meinrepo`)
+     - `PMS_UPDATE_BRANCH` (z. B. `production`)
+     - `PMS_UPDATE_ARCHIVE_URL` (kompletter Archiv-Link, überschreibt die beiden Werte oben).
+   - Stelle sicher, dass die PHP-Erweiterung `ZipArchive` aktiviert ist, damit das Archiv entpackt werden kann.
+
+> **Hinweis:** Stelle sicher, dass der Webserver-Benutzer die notwendigen Berechtigungen für das Git-Repository besitzt. Andernfalls schlägt das Update fehl.
+
+## Web-Frontend
+
+Neben der reinen API steht jetzt ein leichtgewichtiger Administrations-Client zur Verfügung:
+
+- `public/index.html` bildet ein Single-Page-Dashboard für Reservierungen, Zimmer, Housekeeping, Fakturierung, Berichte, Nutzer, Firmen und Gäste.
+- Hinterlege den API-Token im Kopfbereich der Anwendung – er wird im Browser-Storage gespeichert.
+- Starte die Oberfläche lokal zum Beispiel mit
+  ```bash
+  php -S 0.0.0.0:8080 -t public
+  ```
+  und rufe anschließend `http://localhost:8080/` im Browser auf. Die API muss parallel (z. B. über Apache/Nginx oder einen zweiten PHP-Built-in-Server) erreichbar sein.
+- Im Bereich „Firmen“ legst du Unternehmensprofile an und bearbeitest sie; Gäste können direkt im Gästebereich einer Firma zugeordnet oder dort editiert werden.
+- Die Dashboard-Kalenderansicht sortiert Zimmer nach Kategorie, markiert Angereist/Bezahlt/Abgereist farblich und lässt sich per Umschalter zwischen Gast- und Firmenname umstellen; überbuchte Kategorien erscheinen als eigene Zeile, bis eine konkrete Zimmernummer vergeben wurde. Ein Klick auf eine belegte Zelle springt direkt zur entsprechenden Reservierung.
+- Über den Button „Farben anpassen“ im Dashboard gelangst du direkt zu den Kalender-Einstellungen und kannst alle Status-Farben dauerhaft speichern oder zurücksetzen.
+- Die Reservierungsliste bietet farbige Schnellaktionen für Check-in, Zahlungseingang, Check-out und No-Show – ideal, um Gäste schnell als angereist, abgereist oder No-Show zu markieren.
+- Im Reservierungsformular wählst du zunächst Zimmerkategorien (Überbuchung), die Kapazität wird anhand der hinterlegten Kategorie-Belegung geprüft; Zusatzleistungen lassen sich wie gewohnt aktivieren und werden automatisch berücksichtigt.
+- Die Gastauswahl nutzt eine Live-Suche: Gib mindestens zwei Zeichen ein, um bestehende Gäste samt Firmenbezug zu finden – andernfalls legst du direkt einen neuen Gast über die Formularfelder an.
+- Öffnest du eine bestehende Reservierung, zeigt der Formularheader die neue fortlaufende Reservierungsnummer (`RES-000001`, `RES-000002`, …) sowie Schnellaktionen für „Rechnung erstellen“ und „Als bezahlt verbuchen“. Der PDF-Link steht nach der ersten Rechnung direkt bereit.
+- Der Fakturierungsbereich enthält ein Artikel-Panel samt CRUD-Funktionalität, eine Rechnungsmaske mit MwSt.-Berechnung sowie Direktlinks zum PDF-Export.
+- Unter „Einstellungen“ lässt sich das Rechnungslogo als PNG/JPEG hochladen; die Vorschau zeigt unmittelbar das spätere Layout auf der Rechnung.
+
+## REST API für den MVP-Funktionsumfang
+
+Nach dem erfolgreichen Datenbank-Setup stellt `backend/api/index.php` eine schlanke REST-API bereit, die sämtliche MVP-Bereiche abdeckt. **Authentifiziere jede Anfrage (außer den Gastportal-Endpoints) mit** `X-API-Key: <API_TOKEN>` oder `?token=`.
+
+### Front-Office & Reservierungen
+- `GET /backend/api/reservations?status=confirmed&from=2024-01-01&to=2024-01-31` – Übersicht über Reservierungen inklusive Zimmerzuweisungen.
+- `POST /backend/api/reservations` – Legt Gäste (falls nötig), Reservierung sowie Zimmerkategorie-Platzhalter in einem Schritt an. Konkrete Zimmerzuweisungen kannst du später per `rooms` ergänzen. Beispiel-Payload:
+  ```json
+  {
+    "guest": {"first_name": "Max", "last_name": "Mustermann", "email": "max@example.com"},
+    "check_in_date": "2024-02-10",
+    "check_out_date": "2024-02-14",
+    "room_requests": [{"room_type_id": 1, "quantity": 1}],
+    "status": "confirmed",
+    "total_amount": 480,
+    "notes": "Late arrival",
+    "articles": [{"article_id": 3, "multiplier": 4}]
+  }
+  ```
+  Optional kannst du weiterhin `rooms` mitsenden, um konkrete Zimmer zuzuweisen, sowie `rate_plan_id`, falls Preislogiken hinterlegt sind.
+- `POST /backend/api/reservations/{id}/status` – Aktualisiert den Reservierungsstatus (`checked_in`, `paid`, `checked_out`, `no_show` usw.) inklusive Logbuch, Zimmer- und Housekeeping-Updates. Aus Kompatibilitätsgründen funktionieren weiterhin die Kurzpfade `/check-in`, `/check-out`, `/pay` und `/no-show`.
+- `POST /backend/api/reservations/{id}/invoice` – Erstellt auf Basis der Zimmerzuweisungen und Zusatzartikel automatisch eine Rechnung mit fortlaufender Nummer (`INV-000001`, `INV-000002`, …).
+- `POST /backend/api/reservations/{id}/invoice-pay` – Verbucht den offenen Betrag der zuletzt erstellten Rechnung, erzeugt einen Zahlungseintrag und setzt die Reservierung auf `paid`.
+- `POST /backend/api/reservations/{id}/documents` – Hinterlegt Meldescheine oder andere Dateien (es werden Metadaten gespeichert, die Dateiablage erfolgt extern).
+- `GET|POST|PATCH /backend/api/guests` – Verwalten von Gästestammdaten inklusive Firmenzuordnung und optionaler Suchfunktion via `?search=` (inkl. `&limit=` für performante Auto-Vervollständigung).
+- `GET|POST|PATCH /backend/api/companies` – Firmenstammdaten für Reisebüros, Unternehmen oder Agenturen; Gäste lassen sich diesen Einträgen zuweisen.
+
+### Housekeeping & Maintenance
+- `GET /backend/api/rooms?status=in_cleaning` – Filterbare Raumliste inkl. Raumtyp.
+- `PATCH /backend/api/rooms/{id}` – Aktualisiert Status (z. B. `available`, `in_cleaning`, `out_of_order`) und protokolliert automatisch einen Housekeeping-Log.
+- `GET|POST|PATCH /backend/api/housekeeping/tasks` – Aufgabenlisten für Reinigung & Technik, inkl. optionaler Raum- und Mitarbeiterzuweisung.
+
+### Fakturierung & Zahlungen
+- `POST /backend/api/invoices` – Erstellt Rechnungen mit beliebig vielen Positionen; Netto-/Steuer-/Brutto-Summen werden automatisch berechnet. Ohne eigene Nummer erhält jede neue Rechnung automatisch die nächste Sequenz (`INV-000001`, `INV-000002`, …). Mit `type: "correction"` plus `parent_invoice_id` erzeugst du Rechnungskorrekturen inklusive fortlaufender `correction_number` (`COR-000001`, …); Positionen der Ursprungrechnung werden dabei mit negativen Mengen übernommen.
+- `POST /backend/api/payments` – Verbucht Zahlungen (Bar, Karte, externes Gateway) und verknüpft sie mit Rechnungen.
+- `GET /backend/api/invoices/{id}/pdf` – Rendert die Rechnung als PDF (inkl. Rechnungslogo, Netto-/MwSt.-Ausweis und Artikellisten) über die mitgelieferte FPDF-Library.
+  - **Wichtig:** Lade die Standard-Schriftdateien der FPDF-Library (z. B. `helvetica.php`, `courier.php`) manuell in `backend/lib/font/` hoch; sie sind aus lizenzrechtlichen Gründen nicht im Repository enthalten.
+- `GET|POST|PATCH|DELETE /backend/api/articles` – Verwalte abrechenbare Artikel (z. B. Frühstück, Parkplatz). Die Felder `charge_scheme`, `unit_price` und `tax_rate` sorgen dafür, dass Mehrwertsteuer nach deutschem Recht (Standard 19 %, optional z. B. 7 %) korrekt in Rechnungen einfließt.
+
+### Berichte & Analytics
+- `GET /backend/api/reports/occupancy?start=2024-02-01&end=2024-02-07` – Tagesbasierte Auslastungsquote.
+- `GET /backend/api/reports/revenue?start=2024-02-01&end=2024-02-29` – Umsatzübersicht inkl. Steuern und Zahlungsarten.
+- `GET /backend/api/reports/forecast` – Einfache Forecast-Kennzahlen auf Basis kommender Reservierungen.
+
+### Nutzer- & Rollenverwaltung
+- `GET|POST /backend/api/users` – Legt Benutzer mit Passwort-Hash an und weist Rollen zu.
+- `GET|POST /backend/api/roles`, `POST /backend/api/roles/{id}/permissions` sowie `GET|POST /backend/api/permissions` – Rollen-/Rechteverwaltung mit Audit-Logs über `reservation_status_logs` bzw. `audit_logs`.
+
+### Integrationen (Platzhalter)
+- `GET /backend/api/integrations` – Liefert den aktuellen Verbindungsstatus zu Channel-Managern, POS, Türschließsystemen und Buchhaltung.
+
+### Einstellungen
+- `GET /backend/api/settings` – Liefert die verfügbaren Einstellungsbereiche.
+- `GET|PUT|DELETE /backend/api/settings/calendar-colors` – Liest, speichert oder setzt die Kalenderfarben zurück. `PUT` erwartet ein Objekt nach dem Schema `{ "colors": { "confirmed": "#2563eb", "checked_in": "#16a34a", ... } }`.
+- `GET|PUT|DELETE /backend/api/settings/invoice-logo` – Lädt das Rechnungslogo als Base64-Daten, speichert neue Uploads oder entfernt vorhandene Logos.
+
+### Gästeportal / Self-Service
+- `GET /backend/api/guest-portal/reservations/{confirmation}` – Gäste sehen Reservierungsdetails, Zimmer und Dokumente.
+- `POST /backend/api/guest-portal/reservations/{confirmation}/check-in` – Self-Check-in; aktualisiert Reservierungs- und Zimmerstatus.
+- `POST /backend/api/guest-portal/reservations/{confirmation}/documents` – Upload von Meldescheinen (Metadaten) durch den Gast.
+- `POST /backend/api/guest-portal/reservations/{confirmation}/upsell` – Gäste buchen Zusatzleistungen, die als `service_orders` im Backoffice landen.
+
+> Tipp: Für lokale Tests bietet sich `php -S 0.0.0.0:8000 -t backend` an. Die API ist dann unter `http://localhost:8000/api/index.php/...` erreichbar.

--- a/backend/api/index.php
+++ b/backend/api/index.php
@@ -1,0 +1,3203 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../bootstrap.php';
+
+const RESERVATION_STATUSES = [
+    'tentative',
+    'confirmed',
+    'checked_in',
+    'paid',
+    'checked_out',
+    'cancelled',
+    'no_show',
+];
+
+const CALENDAR_COLOR_STATUSES = [
+    'tentative',
+    'confirmed',
+    'checked_in',
+    'paid',
+    'checked_out',
+    'cancelled',
+    'no_show',
+];
+
+const DEFAULT_CALENDAR_COLORS = [
+    'tentative' => '#f97316',
+    'confirmed' => '#2563eb',
+    'checked_in' => '#16a34a',
+    'paid' => '#0ea5e9',
+    'checked_out' => '#6b7280',
+    'cancelled' => '#ef4444',
+    'no_show' => '#7c3aed',
+];
+
+const ARTICLE_CHARGE_SCHEMES = [
+    'per_person_per_day',
+    'per_room_per_day',
+    'per_stay',
+    'per_person',
+    'per_day',
+];
+
+const GERMAN_VAT_STANDARD = 19.0;
+const GERMAN_VAT_REDUCED = 7.0;
+
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+$uri = $_SERVER['REQUEST_URI'] ?? '/';
+$pathInfo = $_SERVER['PATH_INFO'] ?? '';
+if ($pathInfo !== '') {
+    $path = trim($pathInfo, '/');
+} else {
+    $path = parse_url($uri, PHP_URL_PATH) ?? '/';
+    $path = trim($path, '/');
+    $scriptName = trim($_SERVER['SCRIPT_NAME'] ?? '', '/');
+    if ($scriptName !== '' && str_starts_with($path, $scriptName)) {
+        $path = trim(substr($path, strlen($scriptName)), '/');
+    } else {
+        $scriptDir = trim(dirname($_SERVER['SCRIPT_NAME'] ?? ''), '/');
+        if ($scriptDir !== '' && str_starts_with($path, $scriptDir)) {
+            $path = trim(substr($path, strlen($scriptDir)), '/');
+        }
+    }
+}
+$segments = $path === '' ? [] : explode('/', $path);
+$resource = $segments[0] ?? '';
+
+if ($resource === '') {
+    jsonResponse([
+        'name' => 'realPMS Prototype API',
+        'version' => '0.1.0',
+        'resources' => [
+            'room-types',
+            'rate-plans',
+        'rooms',
+        'reservations',
+        'guests',
+        'companies',
+        'housekeeping/tasks',
+        'invoices',
+        'payments',
+        'reports',
+        'users',
+        'roles',
+        'permissions',
+        'integrations',
+        'guest-portal',
+        'settings',
+        'articles',
+    ],
+]);
+}
+
+$publicResources = ['guest-portal'];
+if (!in_array($resource, $publicResources, true)) {
+    requireApiKey();
+}
+
+switch ($resource) {
+    case 'room-types':
+        handleRoomTypes($method, $segments);
+        break;
+    case 'rate-plans':
+        handleRatePlans($method, $segments);
+        break;
+    case 'rooms':
+        handleRooms($method, $segments);
+        break;
+    case 'reservations':
+        handleReservations($method, $segments);
+        break;
+    case 'guests':
+        handleGuests($method, $segments);
+        break;
+    case 'companies':
+        handleCompanies($method, $segments);
+        break;
+    case 'housekeeping':
+        handleHousekeeping($method, $segments);
+        break;
+    case 'invoices':
+        handleInvoices($method, $segments);
+        break;
+    case 'payments':
+        handlePayments($method, $segments);
+        break;
+    case 'reports':
+        handleReports($method, $segments);
+        break;
+    case 'articles':
+        handleArticles($method, $segments);
+        break;
+    case 'users':
+        handleUsers($method, $segments);
+        break;
+    case 'roles':
+        handleRoles($method, $segments);
+        break;
+    case 'permissions':
+        handlePermissions($method, $segments);
+        break;
+    case 'integrations':
+        handleIntegrations($method, $segments);
+        break;
+    case 'guest-portal':
+        handleGuestPortal($method, $segments);
+        break;
+    case 'settings':
+        handleSettings($method, $segments);
+        break;
+    default:
+        jsonResponse(['error' => 'Resource not found.'], 404);
+}
+
+function handleRoomTypes(string $method, array $segments): void
+{
+    $pdo = db();
+    $id = $segments[1] ?? null;
+
+    if ($method === 'GET') {
+        if ($id !== null) {
+            $stmt = $pdo->prepare('SELECT * FROM room_types WHERE id = :id');
+            $stmt->execute(['id' => $id]);
+            $type = $stmt->fetch();
+            if (!$type) {
+                jsonResponse(['error' => 'Room type not found.'], 404);
+            }
+            jsonResponse($type);
+        }
+
+        $stmt = $pdo->query('SELECT * FROM room_types ORDER BY name');
+        jsonResponse($stmt->fetchAll());
+    }
+
+    if ($method === 'POST') {
+        $data = parseJsonBody();
+        if (empty($data['name'])) {
+            jsonResponse(['error' => 'Name is required.'], 422);
+        }
+
+        $stmt = $pdo->prepare('INSERT INTO room_types (name, description, base_occupancy, max_occupancy, base_rate, currency, created_at, updated_at) VALUES (:name, :description, :base_occupancy, :max_occupancy, :base_rate, :currency, :created_at, :updated_at)');
+        $stmt->execute([
+            'name' => $data['name'],
+            'description' => $data['description'] ?? null,
+            'base_occupancy' => $data['base_occupancy'] ?? 1,
+            'max_occupancy' => $data['max_occupancy'] ?? ($data['base_occupancy'] ?? 1),
+            'base_rate' => $data['base_rate'] ?? null,
+            'currency' => $data['currency'] ?? 'EUR',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        jsonResponse(['id' => $pdo->lastInsertId()], 201);
+    }
+
+    if (($method === 'PUT' || $method === 'PATCH') && $id !== null) {
+        $data = parseJsonBody();
+        $fields = ['name', 'description', 'base_occupancy', 'max_occupancy', 'base_rate', 'currency'];
+        $updates = [];
+        $params = ['id' => $id];
+        foreach ($fields as $field) {
+            if (array_key_exists($field, $data)) {
+                $updates[] = sprintf('%s = :%s', $field, $field);
+                $params[$field] = $data[$field];
+            }
+        }
+
+        if (!$updates) {
+            jsonResponse(['error' => 'No changes supplied.'], 422);
+        }
+
+        $updates[] = 'updated_at = :updated_at';
+        $params['updated_at'] = now();
+
+        $stmt = $pdo->prepare(sprintf('UPDATE room_types SET %s WHERE id = :id', implode(', ', $updates)));
+        $stmt->execute($params);
+        jsonResponse(['updated' => true]);
+    }
+
+    jsonResponse(['error' => 'Unsupported method.'], 405);
+}
+
+function handleRatePlans(string $method, array $segments): void
+{
+    $pdo = db();
+    $id = $segments[1] ?? null;
+
+    if ($method === 'GET') {
+        if ($id !== null) {
+            $stmt = $pdo->prepare('SELECT * FROM rate_plans WHERE id = :id');
+            $stmt->execute(['id' => $id]);
+            $plan = $stmt->fetch();
+            if (!$plan) {
+                jsonResponse(['error' => 'Rate plan not found.'], 404);
+            }
+            jsonResponse($plan);
+        }
+
+        $stmt = $pdo->query('SELECT * FROM rate_plans ORDER BY name');
+        jsonResponse($stmt->fetchAll());
+    }
+
+    if ($method === 'POST') {
+        $data = parseJsonBody();
+        if (empty($data['name'])) {
+            jsonResponse(['error' => 'Name is required.'], 422);
+        }
+
+        $stmt = $pdo->prepare('INSERT INTO rate_plans (name, description, base_price, currency, cancellation_policy, created_at, updated_at) VALUES (:name, :description, :base_price, :currency, :cancellation_policy, :created_at, :updated_at)');
+        $stmt->execute([
+            'name' => $data['name'],
+            'description' => $data['description'] ?? null,
+            'base_price' => $data['base_price'] ?? 0,
+            'currency' => $data['currency'] ?? 'EUR',
+            'cancellation_policy' => $data['cancellation_policy'] ?? null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        jsonResponse(['id' => $pdo->lastInsertId()], 201);
+    }
+
+    if (($method === 'PUT' || $method === 'PATCH') && $id !== null) {
+        $data = parseJsonBody();
+        $fields = ['name', 'description', 'base_price', 'currency', 'cancellation_policy'];
+        $updates = [];
+        $params = ['id' => $id];
+        foreach ($fields as $field) {
+            if (array_key_exists($field, $data)) {
+                $updates[] = sprintf('%s = :%s', $field, $field);
+                $params[$field] = $data[$field];
+            }
+        }
+
+        if (!$updates) {
+            jsonResponse(['error' => 'No changes supplied.'], 422);
+        }
+
+        $updates[] = 'updated_at = :updated_at';
+        $params['updated_at'] = now();
+
+        $stmt = $pdo->prepare(sprintf('UPDATE rate_plans SET %s WHERE id = :id', implode(', ', $updates)));
+        $stmt->execute($params);
+        jsonResponse(['updated' => true]);
+    }
+
+    jsonResponse(['error' => 'Unsupported method.'], 405);
+}
+
+function handleRooms(string $method, array $segments): void
+{
+    $pdo = db();
+    $id = $segments[1] ?? null;
+
+    if ($method === 'GET') {
+        if ($id !== null) {
+            $stmt = $pdo->prepare('SELECT rooms.*, room_types.name AS room_type_name, room_types.base_occupancy, room_types.max_occupancy FROM rooms JOIN room_types ON rooms.room_type_id = room_types.id WHERE rooms.id = :id');
+            $stmt->execute(['id' => $id]);
+            $room = $stmt->fetch();
+            if (!$room) {
+                jsonResponse(['error' => 'Room not found.'], 404);
+            }
+            jsonResponse($room);
+        }
+
+        $query = 'SELECT rooms.*, room_types.name AS room_type_name, room_types.base_occupancy, room_types.max_occupancy FROM rooms JOIN room_types ON rooms.room_type_id = room_types.id';
+        $conditions = [];
+        $params = [];
+        if (isset($_GET['status'])) {
+            $conditions[] = 'rooms.status = :status';
+            $params['status'] = $_GET['status'];
+        }
+        if (isset($_GET['room_type_id'])) {
+            $conditions[] = 'rooms.room_type_id = :room_type_id';
+            $params['room_type_id'] = $_GET['room_type_id'];
+        }
+        if ($conditions) {
+            $query .= ' WHERE ' . implode(' AND ', $conditions);
+        }
+        $query .= ' ORDER BY rooms.room_number';
+
+        $stmt = $pdo->prepare($query);
+        $stmt->execute($params);
+        jsonResponse($stmt->fetchAll());
+    }
+
+    if ($method === 'POST') {
+        $data = parseJsonBody();
+        if (empty($data['room_number']) || empty($data['room_type_id'])) {
+            jsonResponse(['error' => 'room_number and room_type_id are required.'], 422);
+        }
+
+        $stmt = $pdo->prepare('INSERT INTO rooms (room_number, room_type_id, floor, status, notes, created_at, updated_at) VALUES (:room_number, :room_type_id, :floor, :status, :notes, :created_at, :updated_at)');
+        $stmt->execute([
+            'room_number' => $data['room_number'],
+            'room_type_id' => $data['room_type_id'],
+            'floor' => $data['floor'] ?? null,
+            'status' => $data['status'] ?? 'available',
+            'notes' => $data['notes'] ?? null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        jsonResponse(['id' => $pdo->lastInsertId()], 201);
+    }
+
+    if (($method === 'PUT' || $method === 'PATCH') && $id !== null) {
+        $data = parseJsonBody();
+        $fields = ['room_number', 'room_type_id', 'floor', 'status', 'notes'];
+        $updates = [];
+        $params = ['id' => $id];
+        foreach ($fields as $field) {
+            if (array_key_exists($field, $data)) {
+                $updates[] = sprintf('%s = :%s', $field, $field);
+                $params[$field] = $data[$field];
+            }
+        }
+
+        if (!$updates) {
+            jsonResponse(['error' => 'No changes supplied.'], 422);
+        }
+
+        if (isset($data['status'])) {
+            logHousekeepingStatus((int) $id, $data['status'], $data['notes'] ?? null, $data['recorded_by'] ?? null);
+        }
+
+        $updates[] = 'updated_at = :updated_at';
+        $params['updated_at'] = now();
+
+        $stmt = $pdo->prepare(sprintf('UPDATE rooms SET %s WHERE id = :id', implode(', ', $updates)));
+        $stmt->execute($params);
+        jsonResponse(['updated' => true]);
+    }
+
+    jsonResponse(['error' => 'Unsupported method.'], 405);
+}
+
+function handleGuests(string $method, array $segments): void
+{
+    $pdo = db();
+    $id = $segments[1] ?? null;
+
+    if ($method === 'GET') {
+        if ($id !== null) {
+            $stmt = $pdo->prepare('SELECT g.*, c.name AS company_name FROM guests g LEFT JOIN companies c ON c.id = g.company_id WHERE g.id = :id');
+            $stmt->execute(['id' => $id]);
+            $guest = $stmt->fetch();
+            if (!$guest) {
+                jsonResponse(['error' => 'Guest not found.'], 404);
+            }
+            jsonResponse($guest);
+        }
+
+        $query = 'SELECT g.*, c.name AS company_name FROM guests g LEFT JOIN companies c ON c.id = g.company_id';
+        $params = [];
+        $limit = null;
+        if (isset($_GET['search']) && $_GET['search'] !== '') {
+            $query .= ' WHERE CONCAT(g.first_name, " ", g.last_name) LIKE :search OR g.email LIKE :search';
+            $params['search'] = '%' . $_GET['search'] . '%';
+        }
+        $query .= ' ORDER BY g.last_name, g.first_name';
+        if (isset($_GET['limit'])) {
+            $limitValue = (int) $_GET['limit'];
+            if ($limitValue > 0) {
+                $limit = min($limitValue, 100);
+            }
+        }
+        if ($limit !== null) {
+            $query .= ' LIMIT ' . $limit;
+        }
+        $stmt = $pdo->prepare($query);
+        $stmt->execute($params);
+        jsonResponse($stmt->fetchAll());
+    }
+
+    if ($method === 'POST' && $id === null) {
+        $data = parseJsonBody();
+        foreach (['first_name', 'last_name'] as $field) {
+            if (empty($data[$field])) {
+                jsonResponse(['error' => sprintf('%s is required.', $field)], 422);
+            }
+        }
+
+        $companyId = normalizeCompanyId($pdo, $data['company_id'] ?? null);
+
+        $stmt = $pdo->prepare('INSERT INTO guests (first_name, last_name, email, phone, address, city, country, company_id, notes, created_at, updated_at) VALUES (:first_name, :last_name, :email, :phone, :address, :city, :country, :company_id, :notes, :created_at, :updated_at)');
+        $stmt->execute([
+            'first_name' => $data['first_name'],
+            'last_name' => $data['last_name'],
+            'email' => $data['email'] ?? null,
+            'phone' => $data['phone'] ?? null,
+            'address' => $data['address'] ?? null,
+            'city' => $data['city'] ?? null,
+            'country' => $data['country'] ?? null,
+            'company_id' => $companyId,
+            'notes' => $data['notes'] ?? null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        jsonResponse(['id' => $pdo->lastInsertId()], 201);
+    }
+
+    if (($method === 'PUT' || $method === 'PATCH') && $id !== null) {
+        $data = parseJsonBody();
+        $fields = ['first_name', 'last_name', 'email', 'phone', 'address', 'city', 'country', 'company_id', 'notes'];
+        $updates = [];
+        $params = ['id' => $id];
+        foreach ($fields as $field) {
+            if (array_key_exists($field, $data)) {
+                if ($field === 'company_id') {
+                    $params[$field] = normalizeCompanyId($pdo, $data[$field]);
+                } else {
+                    $params[$field] = $data[$field];
+                }
+                $updates[] = sprintf('%s = :%s', $field, $field);
+            }
+        }
+        if (!$updates) {
+            jsonResponse(['error' => 'No changes supplied.'], 422);
+        }
+        $updates[] = 'updated_at = :updated_at';
+        $params['updated_at'] = now();
+        $stmt = $pdo->prepare(sprintf('UPDATE guests SET %s WHERE id = :id', implode(', ', $updates)));
+        $stmt->execute($params);
+        jsonResponse(['updated' => true]);
+    }
+
+    jsonResponse(['error' => 'Unsupported method.'], 405);
+}
+
+function handleCompanies(string $method, array $segments): void
+{
+    $pdo = db();
+    $id = $segments[1] ?? null;
+
+    if ($method === 'GET') {
+        if ($id !== null) {
+            $stmt = $pdo->prepare('SELECT * FROM companies WHERE id = :id');
+            $stmt->execute(['id' => $id]);
+            $company = $stmt->fetch();
+            if (!$company) {
+                jsonResponse(['error' => 'Company not found.'], 404);
+            }
+            jsonResponse($company);
+        }
+
+        $query = 'SELECT * FROM companies';
+        $params = [];
+        if (isset($_GET['search']) && $_GET['search'] !== '') {
+            $query .= ' WHERE name LIKE :search OR email LIKE :search';
+            $params['search'] = '%' . $_GET['search'] . '%';
+        }
+        $query .= ' ORDER BY name';
+        $stmt = $pdo->prepare($query);
+        $stmt->execute($params);
+        jsonResponse($stmt->fetchAll());
+    }
+
+    if ($method === 'POST' && $id === null) {
+        $data = parseJsonBody();
+        if (empty($data['name'])) {
+            jsonResponse(['error' => 'Name is required.'], 422);
+        }
+
+        $stmt = $pdo->prepare('INSERT INTO companies (name, email, phone, address, city, country, notes, created_at, updated_at) VALUES (:name, :email, :phone, :address, :city, :country, :notes, :created_at, :updated_at)');
+        $stmt->execute([
+            'name' => $data['name'],
+            'email' => $data['email'] ?? null,
+            'phone' => $data['phone'] ?? null,
+            'address' => $data['address'] ?? null,
+            'city' => $data['city'] ?? null,
+            'country' => $data['country'] ?? null,
+            'notes' => $data['notes'] ?? null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        jsonResponse(['id' => $pdo->lastInsertId()], 201);
+    }
+
+    if (($method === 'PUT' || $method === 'PATCH') && $id !== null) {
+        $data = parseJsonBody();
+        $fields = ['name', 'email', 'phone', 'address', 'city', 'country', 'notes'];
+        $updates = [];
+        $params = ['id' => $id];
+        foreach ($fields as $field) {
+            if (array_key_exists($field, $data)) {
+                if ($field === 'name' && empty($data[$field])) {
+                    jsonResponse(['error' => 'Name is required.'], 422);
+                }
+                $updates[] = sprintf('%s = :%s', $field, $field);
+                $params[$field] = $data[$field];
+            }
+        }
+        if (!$updates) {
+            jsonResponse(['error' => 'No changes supplied.'], 422);
+        }
+        $updates[] = 'updated_at = :updated_at';
+        $params['updated_at'] = now();
+        $stmt = $pdo->prepare(sprintf('UPDATE companies SET %s WHERE id = :id', implode(', ', $updates)));
+        $stmt->execute($params);
+        jsonResponse(['updated' => true]);
+    }
+
+    jsonResponse(['error' => 'Unsupported method.'], 405);
+}
+
+function handleArticles(string $method, array $segments): void
+{
+    $pdo = db();
+    $id = $segments[1] ?? null;
+
+    if ($method === 'GET') {
+        if ($id !== null) {
+            $stmt = $pdo->prepare('SELECT * FROM articles WHERE id = :id');
+            $stmt->execute(['id' => $id]);
+            $article = $stmt->fetch();
+            if (!$article) {
+                jsonResponse(['error' => 'Article not found.'], 404);
+            }
+            jsonResponse($article);
+        }
+
+        $includeInactive = isset($_GET['include_inactive']) && ($_GET['include_inactive'] === '1' || strtolower((string) $_GET['include_inactive']) === 'true');
+        $query = 'SELECT * FROM articles';
+        if (!$includeInactive) {
+            $query .= ' WHERE is_active = 1';
+        }
+        $query .= ' ORDER BY name';
+        $stmt = $pdo->query($query);
+        jsonResponse($stmt->fetchAll());
+    }
+
+    if ($method === 'POST' && $id === null) {
+        $data = parseJsonBody();
+        $normalized = normalizeArticlePayload($data);
+
+        $stmt = $pdo->prepare('INSERT INTO articles (name, description, charge_scheme, unit_price, tax_rate, is_active, created_at, updated_at) VALUES (:name, :description, :charge_scheme, :unit_price, :tax_rate, :is_active, :created_at, :updated_at)');
+        $stmt->execute([
+            'name' => $normalized['name'],
+            'description' => $normalized['description'],
+            'charge_scheme' => $normalized['charge_scheme'],
+            'unit_price' => $normalized['unit_price'],
+            'tax_rate' => $normalized['tax_rate'],
+            'is_active' => $normalized['is_active'],
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        jsonResponse(['id' => $pdo->lastInsertId()], 201);
+    }
+
+    if (($method === 'PUT' || $method === 'PATCH') && $id !== null) {
+        $data = parseJsonBody();
+        $normalized = normalizeArticlePayload($data, false);
+        if (!$normalized) {
+            jsonResponse(['error' => 'No changes supplied.'], 422);
+        }
+
+        $fields = [];
+        $params = ['id' => $id];
+        foreach ($normalized as $key => $value) {
+            $fields[] = sprintf('%s = :%s', $key, $key);
+            $params[$key] = $value;
+        }
+        $fields[] = 'updated_at = :updated_at';
+        $params['updated_at'] = now();
+
+        $sql = sprintf('UPDATE articles SET %s WHERE id = :id', implode(', ', $fields));
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($params);
+
+        jsonResponse(['updated' => true]);
+    }
+
+    if ($method === 'DELETE' && $id !== null) {
+        $stmt = $pdo->prepare('UPDATE articles SET is_active = 0, updated_at = :updated_at WHERE id = :id');
+        $stmt->execute([
+            'updated_at' => now(),
+            'id' => $id,
+        ]);
+        jsonResponse(['deleted' => true]);
+    }
+
+    jsonResponse(['error' => 'Unsupported method.'], 405);
+}
+
+function handleReservations(string $method, array $segments): void
+{
+    $pdo = db();
+    $id = $segments[1] ?? null;
+
+    if ($method === 'GET') {
+        if ($id !== null) {
+            $stmt = $pdo->prepare('SELECT r.*, g.first_name, g.last_name, g.email, g.phone, g.company_id, c.name AS company_name FROM reservations r JOIN guests g ON g.id = r.guest_id LEFT JOIN companies c ON c.id = g.company_id WHERE r.id = :id');
+            $stmt->execute(['id' => $id]);
+            $reservation = $stmt->fetch();
+            if (!$reservation) {
+                jsonResponse(['error' => 'Reservation not found.'], 404);
+            }
+            $reservation['rooms'] = fetchReservationRooms((int) $id);
+            $reservation['room_requests'] = fetchReservationRoomRequests((int) $id, $pdo);
+            $reservation['documents'] = fetchReservationDocuments((int) $id);
+            $reservation['status_history'] = fetchReservationStatusLogs((int) $id);
+            $reservation['articles'] = fetchReservationArticles((int) $id);
+            $reservation['invoices'] = fetchInvoicesForReservation((int) $id);
+            jsonResponse($reservation);
+        }
+
+        $conditions = [];
+        $params = [];
+        $query = 'SELECT r.*, g.first_name, g.last_name, g.company_id, c.name AS company_name FROM reservations r JOIN guests g ON g.id = r.guest_id LEFT JOIN companies c ON c.id = g.company_id';
+        if (isset($_GET['status'])) {
+            $conditions[] = 'r.status = :status';
+            $params['status'] = $_GET['status'];
+        }
+        if (isset($_GET['from']) && validateDate($_GET['from'])) {
+            $conditions[] = 'r.check_in_date >= :from_date';
+            $params['from_date'] = $_GET['from'];
+        }
+        if (isset($_GET['to']) && validateDate($_GET['to'])) {
+            $conditions[] = 'r.check_out_date <= :to_date';
+            $params['to_date'] = $_GET['to'];
+        }
+        if ($conditions) {
+            $query .= ' WHERE ' . implode(' AND ', $conditions);
+        }
+        $query .= ' ORDER BY r.check_in_date DESC';
+
+        $stmt = $pdo->prepare($query);
+        $stmt->execute($params);
+        $reservations = $stmt->fetchAll();
+        foreach ($reservations as &$reservation) {
+            $reservation['rooms'] = fetchReservationRooms((int) $reservation['id']);
+            $reservation['room_requests'] = fetchReservationRoomRequests((int) $reservation['id'], $pdo);
+        }
+        jsonResponse($reservations);
+    }
+
+    if ($method === 'POST' && $id === null) {
+        $data = parseJsonBody();
+        validateReservationPayload($data);
+
+        $guestCount = calculateGuestCount($data['adults'] ?? 1, $data['children'] ?? 0);
+        $roomRequests = normalizeReservationRoomRequests($pdo, $data['room_requests'] ?? []);
+        if (empty($roomRequests) && (empty($data['rooms']) || !is_array($data['rooms']) || count($data['rooms']) === 0)) {
+            jsonResponse(['error' => 'Bitte mindestens eine Zimmerkategorie oder ein Zimmer zuweisen.'], 422);
+        }
+        if (!empty($roomRequests)) {
+            ensureRoomRequestCapacity($roomRequests, $guestCount);
+        }
+
+        $pdo->beginTransaction();
+        try {
+            $guestId = $data['guest_id'] ?? null;
+            if ($guestId === null) {
+                $guestId = createGuest($pdo, $data['guest']);
+            } else {
+                $guestId = (int) $guestId;
+                if ($guestId <= 0) {
+                    jsonResponse(['error' => 'guest_id must reference an existing guest.'], 422);
+                }
+            }
+
+            $confirmation = $data['confirmation_number'] ?? generateConfirmationNumber();
+            $statusValue = isset($data['status']) ? normalizeReservationStatus((string) $data['status']) : 'tentative';
+            if ($statusValue === null) {
+                jsonResponse(['error' => 'Unsupported reservation status.'], 422);
+            }
+            $stmt = $pdo->prepare('INSERT INTO reservations (confirmation_number, guest_id, status, check_in_date, check_out_date, adults, children, rate_plan_id, total_amount, currency, booked_via, notes, created_at, updated_at) VALUES (:confirmation_number, :guest_id, :status, :check_in_date, :check_out_date, :adults, :children, :rate_plan_id, :total_amount, :currency, :booked_via, :notes, :created_at, :updated_at)');
+            $stmt->execute([
+                'confirmation_number' => $confirmation,
+                'guest_id' => $guestId,
+                'status' => $statusValue,
+                'check_in_date' => $data['check_in_date'],
+                'check_out_date' => $data['check_out_date'],
+                'adults' => $data['adults'] ?? 1,
+                'children' => $data['children'] ?? 0,
+                'rate_plan_id' => $data['rate_plan_id'] ?? null,
+                'total_amount' => $data['total_amount'] ?? null,
+                'currency' => $data['currency'] ?? 'EUR',
+                'booked_via' => $data['booked_via'] ?? null,
+                'notes' => $data['notes'] ?? null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            $reservationId = (int) $pdo->lastInsertId();
+            $roomIds = extractRoomIdsFromSelection($data['rooms'] ?? []);
+            if (!empty($roomIds)) {
+                assignRoomsToReservation(
+                    $pdo,
+                    $reservationId,
+                    $data['rooms'] ?? [],
+                    $data['check_in_date'],
+                    $data['check_out_date'],
+                    $guestCount
+                );
+            }
+            $roomCount = count($roomIds);
+            if ($roomCount === 0) {
+                $roomCount = calculateRoomRequestQuantity($roomRequests);
+            }
+            $articleSelections = isset($data['articles']) && is_array($data['articles']) ? $data['articles'] : [];
+            syncReservationArticles(
+                $pdo,
+                $reservationId,
+                $articleSelections,
+                $data['check_in_date'],
+                $data['check_out_date'],
+                $guestCount,
+                $roomCount
+            );
+            syncReservationRoomRequests($pdo, $reservationId, $roomRequests);
+            logReservationStatus($pdo, $reservationId, $statusValue, $data['status_notes'] ?? null, $data['recorded_by'] ?? null);
+            updateRoomsForReservationStatus($pdo, $reservationId, $statusValue, $data['status_notes'] ?? null, $data['recorded_by'] ?? null);
+
+            $pdo->commit();
+            jsonResponse(['id' => $reservationId, 'confirmation_number' => $confirmation], 201);
+        } catch (Throwable $exception) {
+            $pdo->rollBack();
+            $status = ($exception instanceof InvalidArgumentException || $exception instanceof RuntimeException) ? 422 : 500;
+            jsonResponse(['error' => $exception->getMessage()], $status);
+        }
+    }
+
+    if (($method === 'PUT' || $method === 'PATCH') && $id !== null) {
+        $data = parseJsonBody();
+        $fields = ['status', 'check_in_date', 'check_out_date', 'adults', 'children', 'rate_plan_id', 'total_amount', 'currency', 'booked_via', 'notes', 'guest_id'];
+        $updates = [];
+        $params = ['id' => $id];
+        $stmt = $pdo->prepare('SELECT guest_id, adults, children, check_in_date, check_out_date FROM reservations WHERE id = :id');
+        $stmt->execute(['id' => $id]);
+        $currentReservation = $stmt->fetch();
+        if (!$currentReservation) {
+            jsonResponse(['error' => 'Reservation not found.'], 404);
+        }
+
+        $targetAdults = array_key_exists('adults', $data) ? (int) $data['adults'] : (int) $currentReservation['adults'];
+        $targetChildren = array_key_exists('children', $data) ? (int) $data['children'] : (int) $currentReservation['children'];
+        $targetCheckIn = array_key_exists('check_in_date', $data) ? $data['check_in_date'] : $currentReservation['check_in_date'];
+        $targetCheckOut = array_key_exists('check_out_date', $data) ? $data['check_out_date'] : $currentReservation['check_out_date'];
+        $targetGuestId = array_key_exists('guest_id', $data) ? (int) $data['guest_id'] : (int) $currentReservation['guest_id'];
+
+        if ($targetGuestId <= 0) {
+            jsonResponse(['error' => 'guest_id must reference an existing guest.'], 422);
+        }
+
+        $guestCount = calculateGuestCount($targetAdults, $targetChildren);
+        if ($guestCount < 1) {
+            jsonResponse(['error' => 'At least one guest is required for a reservation.'], 422);
+        }
+
+        $roomSelection = !empty($data['rooms']) ? $data['rooms'] : fetchReservationRooms((int) $id);
+        $roomIds = extractRoomIdsFromSelection($roomSelection);
+        $roomCount = count($roomIds);
+        $existingRequests = fetchReservationRoomRequests((int) $id, $pdo);
+        $roomRequestsChanged = array_key_exists('room_requests', $data);
+        $roomRequests = $roomRequestsChanged
+            ? normalizeReservationRoomRequests($pdo, is_array($data['room_requests']) ? $data['room_requests'] : [])
+            : $existingRequests;
+
+        if ($roomCount > 0) {
+            ensureRoomCapacity($pdo, $roomIds, $guestCount);
+        } elseif (!empty($roomRequests)) {
+            ensureRoomRequestCapacity($roomRequests, $guestCount);
+        } else {
+            jsonResponse(['error' => 'Bitte mindestens eine Zimmerkategorie oder ein Zimmer zuweisen.'], 422);
+        }
+
+        if ($roomCount > 0 && empty($data['rooms']) && (array_key_exists('check_in_date', $data) || array_key_exists('check_out_date', $data))) {
+            foreach ($roomIds as $roomId) {
+                if (!isRoomAvailable($pdo, $roomId, $targetCheckIn, $targetCheckOut, (int) $id)) {
+                    jsonResponse(['error' => sprintf('Room %d is not available for the updated stay dates.', $roomId)], 422);
+                }
+            }
+        }
+
+        $roomRequestCount = calculateRoomRequestQuantity($roomRequests);
+        if ($roomCount === 0) {
+            $roomCount = $roomRequestCount;
+        }
+
+        $roomsChanged = !empty($data['rooms']);
+        $datesChanged = array_key_exists('check_in_date', $data) || array_key_exists('check_out_date', $data);
+        $guestChanged = array_key_exists('adults', $data) || array_key_exists('children', $data);
+
+        foreach ($fields as $field) {
+            if (array_key_exists($field, $data)) {
+                if (($field === 'check_in_date' || $field === 'check_out_date') && !validateDate($data[$field])) {
+                    jsonResponse(['error' => sprintf('Invalid date for %s', $field)], 422);
+                }
+                if ($field === 'guest_id') {
+                    $guestValue = (int) $data[$field];
+                    if ($guestValue <= 0) {
+                        jsonResponse(['error' => 'guest_id must reference an existing guest.'], 422);
+                    }
+                    $params[$field] = $guestValue;
+                } elseif ($field === 'status') {
+                    $normalizedStatus = normalizeReservationStatus((string) $data[$field]);
+                    if ($normalizedStatus === null) {
+                        jsonResponse(['error' => 'Unsupported reservation status.'], 422);
+                    }
+                    $params[$field] = $normalizedStatus;
+                } else {
+                    $params[$field] = $data[$field];
+                }
+                $updates[] = sprintf('%s = :%s', $field, $field);
+            }
+        }
+
+        if (!$updates && empty($data['rooms']) && empty($data['guest']) && !$roomRequestsChanged) {
+            jsonResponse(['error' => 'No changes supplied.'], 422);
+        }
+
+        $pdo->beginTransaction();
+        try {
+            if ($updates) {
+                $updates[] = 'updated_at = :updated_at';
+                $params['updated_at'] = now();
+                $stmt = $pdo->prepare(sprintf('UPDATE reservations SET %s WHERE id = :id', implode(', ', $updates)));
+                $stmt->execute($params);
+                if (isset($params['status'])) {
+                    $normalizedStatus = $params['status'];
+                    logReservationStatus($pdo, (int) $id, $normalizedStatus, $data['status_notes'] ?? null, $data['recorded_by'] ?? null);
+                    updateRoomsForReservationStatus($pdo, (int) $id, $normalizedStatus, $data['status_notes'] ?? null, $data['recorded_by'] ?? null);
+                }
+            }
+
+            if (isset($data['guest']) && is_array($data['guest'])) {
+                $guestFields = ['first_name', 'last_name', 'email', 'phone', 'address', 'city', 'country', 'company_id', 'notes'];
+                $guestUpdates = [];
+                $guestParams = ['id' => $targetGuestId];
+                foreach ($guestFields as $field) {
+                    if (array_key_exists($field, $data['guest'])) {
+                        $guestUpdates[] = sprintf('%s = :%s', $field, $field);
+                        if ($field === 'company_id') {
+                            $guestParams[$field] = normalizeCompanyId($pdo, $data['guest'][$field]);
+                        } else {
+                            $guestParams[$field] = $data['guest'][$field];
+                        }
+                    }
+                }
+                if ($guestUpdates) {
+                    $guestUpdates[] = 'updated_at = :updated_at';
+                    $guestParams['updated_at'] = now();
+                    $guestSql = sprintf('UPDATE guests SET %s WHERE id = :id', implode(', ', $guestUpdates));
+                    $pdo->prepare($guestSql)->execute($guestParams);
+                }
+            }
+
+            if (!empty($data['rooms'])) {
+                $pdo->prepare('DELETE FROM reservation_rooms WHERE reservation_id = :id')->execute(['id' => $id]);
+                assignRoomsToReservation(
+                    $pdo,
+                    (int) $id,
+                    $data['rooms'],
+                    $targetCheckIn,
+                    $targetCheckOut,
+                    $guestCount,
+                    (int) $id
+                );
+            }
+
+            if ($roomRequestsChanged) {
+                syncReservationRoomRequests($pdo, (int) $id, $roomRequests);
+            }
+
+            if (array_key_exists('articles', $data)) {
+                $articleSelections = is_array($data['articles']) ? $data['articles'] : [];
+                syncReservationArticles(
+                    $pdo,
+                    (int) $id,
+                    $articleSelections,
+                    $targetCheckIn,
+                    $targetCheckOut,
+                    $guestCount,
+                    $roomCount
+                );
+            } elseif ($roomsChanged || $datesChanged || $guestChanged || $roomRequestsChanged) {
+                recalculateReservationArticles(
+                    $pdo,
+                    (int) $id,
+                    $targetCheckIn,
+                    $targetCheckOut,
+                    $guestCount,
+                    $roomCount
+                );
+            }
+
+            $pdo->commit();
+            jsonResponse(['updated' => true]);
+        } catch (Throwable $exception) {
+            $pdo->rollBack();
+            $status = ($exception instanceof InvalidArgumentException || $exception instanceof RuntimeException) ? 422 : 500;
+            jsonResponse(['error' => $exception->getMessage()], $status);
+        }
+    }
+
+    if ($method === 'POST' && $id !== null && isset($segments[2])) {
+        $action = $segments[2];
+        if ($action === 'status') {
+            $data = parseJsonBody();
+            $targetStatus = $data['status'] ?? null;
+            if (!is_string($targetStatus)) {
+                jsonResponse(['error' => 'status is required.'], 422);
+            }
+            handleReservationStatusChange((int) $id, $targetStatus, $data);
+        } elseif ($action === 'check-in') {
+            $data = parseJsonBody();
+            handleReservationStatusChange((int) $id, 'checked_in', $data);
+        } elseif ($action === 'check-out') {
+            $data = parseJsonBody();
+            handleReservationStatusChange((int) $id, 'checked_out', $data);
+        } elseif ($action === 'pay') {
+            $data = parseJsonBody();
+            handleReservationStatusChange((int) $id, 'paid', $data);
+        } elseif ($action === 'no-show') {
+            $data = parseJsonBody();
+            handleReservationStatusChange((int) $id, 'no_show', $data);
+        } elseif ($action === 'invoice') {
+            $data = parseJsonBody();
+            try {
+                $invoice = createReservationInvoice((int) $id, $data);
+                jsonResponse($invoice, 201);
+            } catch (Throwable $exception) {
+                $status = $exception instanceof InvalidArgumentException ? 422 : 500;
+                jsonResponse(['error' => $exception->getMessage()], $status);
+            }
+        } elseif ($action === 'invoice-pay') {
+            $data = parseJsonBody();
+            try {
+                $result = payReservationInvoice((int) $id, $data);
+                jsonResponse($result);
+            } catch (Throwable $exception) {
+                $status = $exception instanceof InvalidArgumentException ? 422 : 500;
+                jsonResponse(['error' => $exception->getMessage()], $status);
+            }
+        } elseif ($action === 'documents') {
+            $data = parseJsonBody();
+            addReservationDocument((int) $id, $data);
+        } else {
+            jsonResponse(['error' => 'Unknown reservation action.'], 400);
+        }
+        return;
+    }
+
+    jsonResponse(['error' => 'Unsupported method.'], 405);
+}
+
+function handleReservationStatusChange(int $reservationId, string $status, ?array $payload = null): void
+{
+    $normalizedStatus = normalizeReservationStatus($status);
+    if ($normalizedStatus === null) {
+        jsonResponse(['error' => 'Unsupported reservation status.'], 422);
+    }
+
+    $pdo = db();
+    $exists = $pdo->prepare('SELECT id FROM reservations WHERE id = :id');
+    $exists->execute(['id' => $reservationId]);
+    if ($exists->fetchColumn() === false) {
+        jsonResponse(['error' => 'Reservation not found.'], 404);
+    }
+
+    $data = $payload ?? parseJsonBody();
+    $notes = $data['notes'] ?? null;
+    $recordedBy = $data['recorded_by'] ?? null;
+
+    $pdo->beginTransaction();
+    try {
+        applyReservationStatusChange($pdo, $reservationId, $normalizedStatus, $notes, $recordedBy);
+
+        $pdo->commit();
+    } catch (Throwable $exception) {
+        $pdo->rollBack();
+        jsonResponse(['error' => 'Unable to update reservation status.', 'details' => $exception->getMessage()], 500);
+    }
+
+    jsonResponse(['status' => $normalizedStatus]);
+}
+
+function applyReservationStatusChange(PDO $pdo, int $reservationId, string $status, ?string $notes, $recordedBy): void
+{
+    $stmt = $pdo->prepare('UPDATE reservations SET status = :status, updated_at = :updated_at WHERE id = :id');
+    $stmt->execute([
+        'status' => $status,
+        'updated_at' => now(),
+        'id' => $reservationId,
+    ]);
+
+    logReservationStatus($pdo, $reservationId, $status, $notes, $recordedBy);
+    updateRoomsForReservationStatus($pdo, $reservationId, $status, $notes, $recordedBy);
+}
+
+function validateReservationPayload(array $data): void
+{
+    foreach (['check_in_date', 'check_out_date'] as $field) {
+        if (empty($data[$field]) || !validateDate($data[$field])) {
+            jsonResponse(['error' => sprintf('Invalid or missing %s', $field)], 422);
+        }
+    }
+
+    if (!isset($data['guest_id']) && empty($data['guest'])) {
+        jsonResponse(['error' => 'Guest information is required.'], 422);
+    }
+
+    if (isset($data['guest'])) {
+        foreach (['first_name', 'last_name'] as $field) {
+            if (empty($data['guest'][$field])) {
+                jsonResponse(['error' => sprintf('Guest field %s is required.', $field)], 422);
+            }
+        }
+    }
+
+    if (isset($data['rooms']) && !is_array($data['rooms'])) {
+        jsonResponse(['error' => 'rooms must be provided as an array when supplied.'], 422);
+    }
+
+    if (isset($data['room_requests']) && !is_array($data['room_requests'])) {
+        jsonResponse(['error' => 'room_requests must be provided as an array when supplied.'], 422);
+    }
+
+    $guestCount = calculateGuestCount($data['adults'] ?? 1, $data['children'] ?? 0);
+    if ($guestCount < 1) {
+        jsonResponse(['error' => 'At least one guest is required for a reservation.'], 422);
+    }
+
+    if (isset($data['status']) && normalizeReservationStatus((string) $data['status']) === null) {
+        jsonResponse(['error' => 'Unsupported reservation status.'], 422);
+    }
+
+    if (isset($data['articles'])) {
+        if (!is_array($data['articles'])) {
+            jsonResponse(['error' => 'articles must be an array.'], 422);
+        }
+        foreach ($data['articles'] as $article) {
+            if (!is_array($article) || empty($article['article_id'])) {
+                jsonResponse(['error' => 'Each article selection requires an article_id.'], 422);
+            }
+            if (isset($article['multiplier']) && (float) $article['multiplier'] < 0) {
+                jsonResponse(['error' => 'Article multiplier cannot be negative.'], 422);
+            }
+            if (isset($article['quantity']) && (float) $article['quantity'] < 0) {
+                jsonResponse(['error' => 'Article quantity cannot be negative.'], 422);
+            }
+        }
+    }
+}
+
+function calculateGuestCount($adults, $children): int
+{
+    $adultCount = max(0, (int) $adults);
+    $childCount = max(0, (int) $children);
+
+    return $adultCount + $childCount;
+}
+
+function normalizeArticlePayload(array $data, bool $requireAll = true): array
+{
+    if (!is_array($data)) {
+        jsonResponse(['error' => 'Invalid payload.'], 422);
+    }
+
+    $normalized = [];
+
+    if ($requireAll || array_key_exists('name', $data)) {
+        $name = trim((string) ($data['name'] ?? ''));
+        if ($name === '' && $requireAll) {
+            jsonResponse(['error' => 'Name is required.'], 422);
+        }
+        if ($name !== '') {
+            $normalized['name'] = $name;
+        }
+    }
+
+    if ($requireAll || array_key_exists('description', $data)) {
+        $description = isset($data['description']) ? trim((string) $data['description']) : null;
+        $normalized['description'] = $description !== '' ? $description : null;
+    }
+
+    if ($requireAll || array_key_exists('charge_scheme', $data)) {
+        $scheme = $data['charge_scheme'] ?? null;
+        $normalizedScheme = normalizeChargeScheme($scheme, !$requireAll);
+        if ($normalizedScheme !== null) {
+            $normalized['charge_scheme'] = $normalizedScheme;
+        } elseif ($requireAll) {
+            $normalized['charge_scheme'] = 'per_person_per_day';
+        }
+    }
+
+    if ($requireAll || array_key_exists('unit_price', $data)) {
+        $unitPrice = isset($data['unit_price']) ? (float) $data['unit_price'] : 0.0;
+        if ($unitPrice < 0) {
+            jsonResponse(['error' => 'unit_price must be zero or positive.'], 422);
+        }
+        $normalized['unit_price'] = round($unitPrice, 2);
+    }
+
+    if ($requireAll || array_key_exists('tax_rate', $data)) {
+        $taxRate = isset($data['tax_rate']) ? (float) $data['tax_rate'] : GERMAN_VAT_STANDARD;
+        if ($taxRate < 0) {
+            jsonResponse(['error' => 'tax_rate must be zero or positive.'], 422);
+        }
+        $normalized['tax_rate'] = round($taxRate, 2);
+    }
+
+    if ($requireAll || array_key_exists('is_active', $data)) {
+        $isActive = isset($data['is_active']) ? (int) filter_var($data['is_active'], FILTER_VALIDATE_BOOLEAN) : 1;
+        $normalized['is_active'] = $isActive ? 1 : 0;
+    }
+
+    if ($requireAll) {
+        return $normalized;
+    }
+
+    return array_filter(
+        $normalized,
+        static fn ($value) => $value !== null && $value !== '' && $value !== []
+    );
+}
+
+function normalizeChargeScheme($value, bool $allowNull = false): ?string
+{
+    if ($value === null || $value === '') {
+        return $allowNull ? null : 'per_person_per_day';
+    }
+
+    $scheme = strtolower((string) $value);
+    if (!in_array($scheme, ARTICLE_CHARGE_SCHEMES, true)) {
+        jsonResponse(['error' => 'Unsupported article charge scheme.'], 422);
+    }
+
+    return $scheme;
+}
+
+function normalizeRoomAssignments(array $rooms): array
+{
+    $assignments = [];
+    foreach ($rooms as $room) {
+        if (is_array($room)) {
+            $roomId = (int) ($room['room_id'] ?? 0);
+            $nightlyRate = $room['nightly_rate'] ?? null;
+            $currency = $room['currency'] ?? null;
+        } else {
+            $roomId = (int) $room;
+            $nightlyRate = null;
+            $currency = null;
+        }
+
+        if ($roomId === 0) {
+            throw new InvalidArgumentException('room_id is required for each room assignment.');
+        }
+
+        $assignments[] = [
+            'room_id' => $roomId,
+            'nightly_rate' => $nightlyRate,
+            'currency' => $currency,
+        ];
+    }
+
+    return $assignments;
+}
+
+function extractRoomIdsFromSelection(array $rooms): array
+{
+    return array_column(normalizeRoomAssignments($rooms), 'room_id');
+}
+
+function ensureRoomCapacity(PDO $pdo, array $roomIds, int $guestCount): void
+{
+    $uniqueRoomIds = array_values(array_unique(array_map('intval', $roomIds)));
+    if (empty($uniqueRoomIds)) {
+        throw new InvalidArgumentException('At least one room must be selected.');
+    }
+    if ($guestCount < 1) {
+        throw new InvalidArgumentException('At least one guest is required for a reservation.');
+    }
+
+    $placeholders = implode(', ', array_fill(0, count($uniqueRoomIds), '?'));
+    $sql = <<<SQL
+        SELECT rooms.id, rooms.room_number, room_types.name AS room_type_name, room_types.max_occupancy
+        FROM rooms
+        JOIN room_types ON room_types.id = rooms.room_type_id
+        WHERE rooms.id IN ($placeholders)
+    SQL;
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($uniqueRoomIds);
+    $records = $stmt->fetchAll();
+
+    if (count($records) !== count($uniqueRoomIds)) {
+        throw new RuntimeException('One or more selected rooms could not be found.');
+    }
+
+    $totalCapacity = 0;
+    foreach ($records as $record) {
+        $capacity = (int) ($record['max_occupancy'] ?? 0);
+        if ($capacity <= 0) {
+            $roomLabel = $record['room_number'] ?? ('#' . $record['id']);
+            $typeLabel = $record['room_type_name'] ?? '';
+            throw new RuntimeException(sprintf('Room %s%s has no defined capacity.', $roomLabel, $typeLabel ? ' (' . $typeLabel . ')' : ''));
+        }
+        $totalCapacity += $capacity;
+    }
+
+    if ($guestCount > $totalCapacity) {
+        $labels = array_map(
+            static function ($record): string {
+                $roomLabel = $record['room_number'] ?? ('#' . $record['id']);
+                return $record['room_type_name']
+                    ? sprintf('%s (%s)', $roomLabel, $record['room_type_name'])
+                    : $roomLabel;
+            },
+            $records
+        );
+        throw new RuntimeException(sprintf(
+            'Selected rooms (%s) can accommodate up to %d guests, but %d were provided.',
+            implode(', ', $labels),
+            $totalCapacity,
+            $guestCount
+        ));
+    }
+}
+
+function normalizeReservationRoomRequests(PDO $pdo, array $requests): array
+{
+    if (empty($requests)) {
+        return [];
+    }
+
+    $normalized = [];
+    $typeIds = [];
+    foreach ($requests as $request) {
+        if (!is_array($request)) {
+            jsonResponse(['error' => 'room_requests entries must be objects with room_type_id and quantity.'], 422);
+        }
+        $roomTypeId = isset($request['room_type_id']) ? (int) $request['room_type_id'] : 0;
+        if ($roomTypeId <= 0) {
+            jsonResponse(['error' => 'room_type_id is required for each room request.'], 422);
+        }
+        $quantity = isset($request['quantity']) ? (int) $request['quantity'] : 1;
+        if ($quantity <= 0) {
+            jsonResponse(['error' => 'quantity must be at least 1 for each room request.'], 422);
+        }
+        $normalized[] = [
+            'room_type_id' => $roomTypeId,
+            'quantity' => $quantity,
+        ];
+        $typeIds[$roomTypeId] = true;
+    }
+
+    $placeholders = implode(', ', array_fill(0, count($typeIds), '?'));
+    $stmt = $pdo->prepare("SELECT id, name, base_occupancy, max_occupancy FROM room_types WHERE id IN ($placeholders)");
+    $stmt->execute(array_keys($typeIds));
+    $roomTypes = [];
+    while ($row = $stmt->fetch()) {
+        $roomTypes[(int) $row['id']] = $row;
+    }
+
+    if (count($roomTypes) !== count($typeIds)) {
+        jsonResponse(['error' => 'Eine angegebene Zimmerkategorie wurde nicht gefunden.'], 422);
+    }
+
+    $aggregated = [];
+    foreach ($normalized as $entry) {
+        $type = $roomTypes[$entry['room_type_id']];
+        $capacity = (int) ($type['max_occupancy'] ?? 0);
+        if ($capacity <= 0) {
+            $capacity = (int) ($type['base_occupancy'] ?? 0);
+        }
+        if ($capacity <= 0) {
+            jsonResponse(['error' => sprintf('Für die Kategorie %s ist keine Kapazität hinterlegt.', $type['name'] ?? ('#' . $entry['room_type_id']))], 422);
+        }
+
+        if (!isset($aggregated[$entry['room_type_id']])) {
+            $aggregated[$entry['room_type_id']] = [
+                'room_type_id' => $entry['room_type_id'],
+                'quantity' => $entry['quantity'],
+                'room_type_name' => $type['name'] ?? null,
+                'capacity_per_unit' => $capacity,
+            ];
+        } else {
+            $aggregated[$entry['room_type_id']]['quantity'] += $entry['quantity'];
+        }
+    }
+
+    return array_values($aggregated);
+}
+
+function calculateRoomRequestCapacity(array $requests): int
+{
+    $total = 0;
+    foreach ($requests as $request) {
+        $capacity = (int) ($request['capacity_per_unit'] ?? 0);
+        $quantity = max(0, (int) ($request['quantity'] ?? 0));
+        if ($capacity > 0 && $quantity > 0) {
+            $total += $capacity * $quantity;
+        }
+    }
+
+    return $total;
+}
+
+function calculateRoomRequestQuantity(array $requests): int
+{
+    $total = 0;
+    foreach ($requests as $request) {
+        $total += max(0, (int) ($request['quantity'] ?? 0));
+    }
+
+    return $total;
+}
+
+function ensureRoomRequestCapacity(array $requests, int $guestCount): void
+{
+    if ($guestCount < 1) {
+        jsonResponse(['error' => 'At least one guest is required for a reservation.'], 422);
+    }
+
+    $capacity = calculateRoomRequestCapacity($requests);
+    if ($capacity <= 0) {
+        jsonResponse(['error' => 'Für die ausgewählten Kategorien ist keine Kapazität hinterlegt.'], 422);
+    }
+
+    if ($guestCount > $capacity) {
+        $labels = array_map(
+            static function (array $request): string {
+                $name = $request['room_type_name'] ?? ('Kategorie #' . $request['room_type_id']);
+                $quantity = max(1, (int) ($request['quantity'] ?? 1));
+                return sprintf('%s × %d', $name, $quantity);
+            },
+            $requests
+        );
+
+        jsonResponse([
+            'error' => sprintf(
+                'Die ausgewählten Kategorien (%s) bieten insgesamt Platz für %d Gäste, angefragt wurden jedoch %d.',
+                implode(', ', $labels),
+                $capacity,
+                $guestCount
+            ),
+        ], 422);
+    }
+}
+
+function syncReservationRoomRequests(PDO $pdo, int $reservationId, array $requests): void
+{
+    $pdo->prepare('DELETE FROM reservation_room_requests WHERE reservation_id = :id')->execute(['id' => $reservationId]);
+
+    if (empty($requests)) {
+        return;
+    }
+
+    $stmt = $pdo->prepare('INSERT INTO reservation_room_requests (reservation_id, room_type_id, quantity, created_at, updated_at) VALUES (:reservation_id, :room_type_id, :quantity, :created_at, :updated_at)');
+    foreach ($requests as $request) {
+        $stmt->execute([
+            'reservation_id' => $reservationId,
+            'room_type_id' => $request['room_type_id'],
+            'quantity' => max(1, (int) $request['quantity']),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}
+
+function fetchReservationRoomRequests(int $reservationId, ?PDO $pdo = null): array
+{
+    $pdo = $pdo ?? db();
+    $sql = <<<SQL
+        SELECT rrr.id, rrr.room_type_id, rrr.quantity, rt.name AS room_type_name, rt.base_occupancy, rt.max_occupancy
+        FROM reservation_room_requests rrr
+        JOIN room_types rt ON rt.id = rrr.room_type_id
+        WHERE rrr.reservation_id = :reservation_id
+        ORDER BY rt.name
+    SQL;
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute(['reservation_id' => $reservationId]);
+    $records = $stmt->fetchAll();
+
+    return array_map(
+        static function (array $record): array {
+            $capacity = (int) ($record['max_occupancy'] ?? 0);
+            if ($capacity <= 0) {
+                $capacity = (int) ($record['base_occupancy'] ?? 0);
+            }
+            return [
+                'id' => $record['id'],
+                'room_type_id' => (int) $record['room_type_id'],
+                'quantity' => (int) $record['quantity'],
+                'room_type_name' => $record['room_type_name'],
+                'capacity_per_unit' => $capacity > 0 ? $capacity : null,
+            ];
+        },
+        $records
+    );
+}
+
+function createGuest(PDO $pdo, array $guest): int
+{
+    $companyId = normalizeCompanyId($pdo, $guest['company_id'] ?? null);
+
+    $stmt = $pdo->prepare('INSERT INTO guests (first_name, last_name, email, phone, address, city, country, company_id, notes, created_at, updated_at) VALUES (:first_name, :last_name, :email, :phone, :address, :city, :country, :company_id, :notes, :created_at, :updated_at)');
+    $stmt->execute([
+        'first_name' => $guest['first_name'],
+        'last_name' => $guest['last_name'],
+        'email' => $guest['email'] ?? null,
+        'phone' => $guest['phone'] ?? null,
+        'address' => $guest['address'] ?? null,
+        'city' => $guest['city'] ?? null,
+        'country' => $guest['country'] ?? null,
+        'company_id' => $companyId,
+        'notes' => $guest['notes'] ?? null,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    return (int) $pdo->lastInsertId();
+}
+
+function normalizeCompanyId(PDO $pdo, mixed $value): ?int
+{
+    if ($value === null) {
+        return null;
+    }
+
+    if (is_string($value)) {
+        $trimmed = trim($value);
+        if ($trimmed === '') {
+            return null;
+        }
+        $value = $trimmed;
+    }
+
+    $companyId = (int) $value;
+    if ($companyId <= 0) {
+        jsonResponse(['error' => 'company_id must reference an existing company.'], 422);
+    }
+
+    ensureCompanyExists($pdo, $companyId);
+
+    return $companyId;
+}
+
+function ensureCompanyExists(PDO $pdo, int $companyId): void
+{
+    $stmt = $pdo->prepare('SELECT id FROM companies WHERE id = :id');
+    $stmt->execute(['id' => $companyId]);
+    if ($stmt->fetchColumn() === false) {
+        jsonResponse(['error' => 'company_id must reference an existing company.'], 422);
+    }
+}
+
+function assignRoomsToReservation(PDO $pdo, int $reservationId, array $rooms, string $checkIn, string $checkOut, int $guestCount, ?int $ignoreReservationId = null): void
+{
+    $assignments = normalizeRoomAssignments($rooms);
+    $roomIds = array_column($assignments, 'room_id');
+
+    ensureRoomCapacity($pdo, $roomIds, $guestCount);
+
+    foreach ($assignments as $assignment) {
+        $roomId = $assignment['room_id'];
+        if (!isRoomAvailable($pdo, $roomId, $checkIn, $checkOut, $ignoreReservationId ?? $reservationId)) {
+            throw new RuntimeException(sprintf('Room %d is not available for the selected dates.', $roomId));
+        }
+
+        $stmt = $pdo->prepare('INSERT INTO reservation_rooms (reservation_id, room_id, nightly_rate, currency) VALUES (:reservation_id, :room_id, :nightly_rate, :currency)');
+        $stmt->execute([
+            'reservation_id' => $reservationId,
+            'room_id' => $roomId,
+            'nightly_rate' => $assignment['nightly_rate'],
+            'currency' => $assignment['currency'],
+        ]);
+    }
+}
+
+function isRoomAvailable(PDO $pdo, int $roomId, string $checkIn, string $checkOut, ?int $ignoreReservationId = null): bool
+{
+    $query = 'SELECT COUNT(*) FROM reservation_rooms rr JOIN reservations r ON rr.reservation_id = r.id WHERE rr.room_id = :room_id AND r.status NOT IN (\'cancelled\', \'no_show\') AND NOT (r.check_out_date <= :check_in OR r.check_in_date >= :check_out)';
+    $params = [
+        'room_id' => $roomId,
+        'check_in' => $checkIn,
+        'check_out' => $checkOut,
+    ];
+    if ($ignoreReservationId !== null) {
+        $query .= ' AND r.id <> :reservation_id';
+        $params['reservation_id'] = $ignoreReservationId;
+    }
+    $stmt = $pdo->prepare($query);
+    $stmt->execute($params);
+    return (int) $stmt->fetchColumn() === 0;
+}
+
+function fetchReservationRooms(int $reservationId): array
+{
+    $pdo = db();
+    $sql = 'SELECT rr.*, rooms.room_number, rooms.room_type_id, rt.name AS room_type_name, rt.base_rate AS room_type_base_rate'
+        . ' FROM reservation_rooms rr'
+        . ' JOIN rooms ON rooms.id = rr.room_id'
+        . ' LEFT JOIN room_types rt ON rt.id = rooms.room_type_id'
+        . ' WHERE rr.reservation_id = :id';
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute(['id' => $reservationId]);
+    return $stmt->fetchAll();
+}
+
+function fetchReservationDocuments(int $reservationId): array
+{
+    $pdo = db();
+    $stmt = $pdo->prepare('SELECT * FROM reservation_documents WHERE reservation_id = :id ORDER BY uploaded_at DESC');
+    $stmt->execute(['id' => $reservationId]);
+    return $stmt->fetchAll();
+}
+
+function fetchReservationArticles(int $reservationId): array
+{
+    $pdo = db();
+    $stmt = $pdo->prepare('SELECT ra.*, a.name AS article_name FROM reservation_articles ra LEFT JOIN articles a ON a.id = ra.article_id WHERE ra.reservation_id = :id ORDER BY ra.id');
+    $stmt->execute(['id' => $reservationId]);
+    return $stmt->fetchAll();
+}
+
+function fetchReservationStatusLogs(int $reservationId): array
+{
+    $pdo = db();
+    $stmt = $pdo->prepare('SELECT * FROM reservation_status_logs WHERE reservation_id = :id ORDER BY recorded_at DESC');
+    $stmt->execute(['id' => $reservationId]);
+    return $stmt->fetchAll();
+}
+
+function logReservationStatus(PDO $pdo, int $reservationId, string $status, ?string $notes, $recordedBy): void
+{
+    $stmt = $pdo->prepare('INSERT INTO reservation_status_logs (reservation_id, status, notes, recorded_by, recorded_at) VALUES (:reservation_id, :status, :notes, :recorded_by, :recorded_at)');
+    $stmt->execute([
+        'reservation_id' => $reservationId,
+        'status' => $status,
+        'notes' => $notes,
+        'recorded_by' => $recordedBy,
+        'recorded_at' => now(),
+    ]);
+}
+
+function addReservationDocument(int $reservationId, array $data): void
+{
+    if (empty($data['document_type'])) {
+        jsonResponse(['error' => 'document_type is required.'], 422);
+    }
+
+    $pdo = db();
+    $stmt = $pdo->prepare('INSERT INTO reservation_documents (reservation_id, document_type, file_name, file_path, metadata, uploaded_by, uploaded_at) VALUES (:reservation_id, :document_type, :file_name, :file_path, :metadata, :uploaded_by, :uploaded_at)');
+    $stmt->execute([
+        'reservation_id' => $reservationId,
+        'document_type' => $data['document_type'],
+        'file_name' => $data['file_name'] ?? null,
+        'file_path' => $data['file_path'] ?? null,
+        'metadata' => isset($data['metadata']) ? json_encode($data['metadata']) : null,
+        'uploaded_by' => $data['uploaded_by'] ?? null,
+        'uploaded_at' => now(),
+    ]);
+
+    jsonResponse(['created' => true], 201);
+}
+
+function syncReservationArticles(PDO $pdo, int $reservationId, array $articles, string $checkIn, string $checkOut, int $guestCount, int $roomCount): void
+{
+    $pdo->prepare('DELETE FROM reservation_articles WHERE reservation_id = :id')->execute(['id' => $reservationId]);
+
+    if (empty($articles)) {
+        return;
+    }
+
+    $articleIds = [];
+    foreach ($articles as $article) {
+        $articleId = isset($article['article_id']) ? (int) $article['article_id'] : 0;
+        if ($articleId <= 0) {
+            throw new InvalidArgumentException('article_id must reference an existing article.');
+        }
+        $articleIds[] = $articleId;
+    }
+
+    if (empty($articleIds)) {
+        return;
+    }
+
+    $uniqueIds = array_values(array_unique($articleIds));
+    $placeholders = implode(', ', array_fill(0, count($uniqueIds), '?'));
+    $stmt = $pdo->prepare("SELECT * FROM articles WHERE id IN ($placeholders)");
+    $stmt->execute($uniqueIds);
+    $definitions = [];
+    foreach ($stmt->fetchAll() as $definition) {
+        $definitions[(int) $definition['id']] = $definition;
+    }
+
+    $insert = $pdo->prepare('INSERT INTO reservation_articles (reservation_id, article_id, description, charge_scheme, multiplier, quantity, unit_price, tax_rate, total_amount, created_at, updated_at) VALUES (:reservation_id, :article_id, :description, :charge_scheme, :multiplier, :quantity, :unit_price, :tax_rate, :total_amount, :created_at, :updated_at)');
+
+    foreach ($articles as $article) {
+        $articleId = (int) ($article['article_id'] ?? 0);
+        if ($articleId <= 0 || !isset($definitions[$articleId])) {
+            throw new InvalidArgumentException('article_id must reference an existing article.');
+        }
+        $definition = $definitions[$articleId];
+        $scheme = normalizeChargeScheme($article['charge_scheme'] ?? $definition['charge_scheme']);
+        $rawMultiplier = $article['multiplier'] ?? ($article['quantity'] ?? 1);
+        $multiplier = max(0.0, (float) $rawMultiplier);
+        if ($multiplier <= 0.0) {
+            continue;
+        }
+        $unitPrice = array_key_exists('unit_price', $article) ? (float) $article['unit_price'] : (float) ($definition['unit_price'] ?? 0);
+        if ($unitPrice < 0) {
+            $unitPrice = 0;
+        }
+        $taxRate = array_key_exists('tax_rate', $article) ? (float) $article['tax_rate'] : (float) ($definition['tax_rate'] ?? GERMAN_VAT_STANDARD);
+        if ($taxRate < 0) {
+            $taxRate = 0;
+        }
+
+        $quantity = calculateReservationArticleQuantity($scheme, $checkIn, $checkOut, $guestCount, $roomCount, $multiplier);
+        if ($quantity <= 0) {
+            continue;
+        }
+
+        $insert->execute([
+            'reservation_id' => $reservationId,
+            'article_id' => $articleId,
+            'description' => $definition['name'] ?? ('Artikel ' . $articleId),
+            'charge_scheme' => $scheme,
+            'multiplier' => round($multiplier, 2),
+            'quantity' => round($quantity, 2),
+            'unit_price' => round($unitPrice, 2),
+            'tax_rate' => round($taxRate, 2),
+            'total_amount' => round($quantity * $unitPrice, 2),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}
+
+function recalculateReservationArticles(PDO $pdo, int $reservationId, string $checkIn, string $checkOut, int $guestCount, int $roomCount): void
+{
+    $stmt = $pdo->prepare('SELECT id, charge_scheme, multiplier, unit_price FROM reservation_articles WHERE reservation_id = :id');
+    $stmt->execute(['id' => $reservationId]);
+    $records = $stmt->fetchAll();
+    if (!$records) {
+        return;
+    }
+
+    $update = $pdo->prepare('UPDATE reservation_articles SET quantity = :quantity, total_amount = :total_amount, updated_at = :updated_at WHERE id = :id');
+    foreach ($records as $record) {
+        $scheme = normalizeChargeScheme($record['charge_scheme'] ?? null);
+        $multiplier = isset($record['multiplier']) ? (float) $record['multiplier'] : 1.0;
+        if ($multiplier <= 0) {
+            $quantity = 0.0;
+            $total = 0.0;
+        } else {
+            $quantity = calculateReservationArticleQuantity($scheme, $checkIn, $checkOut, $guestCount, $roomCount, $multiplier);
+            $unitPrice = isset($record['unit_price']) ? (float) $record['unit_price'] : 0.0;
+            $total = round($quantity * $unitPrice, 2);
+        }
+
+        $update->execute([
+            'quantity' => round($quantity, 2),
+            'total_amount' => $total,
+            'updated_at' => now(),
+            'id' => $record['id'],
+        ]);
+    }
+}
+
+function calculateStayNights(string $checkIn, string $checkOut): int
+{
+    $start = DateTimeImmutable::createFromFormat('Y-m-d', $checkIn);
+    $end = DateTimeImmutable::createFromFormat('Y-m-d', $checkOut);
+    if (!$start || !$end) {
+        return 0;
+    }
+
+    $diff = $start->diff($end);
+    return max(0, (int) $diff->days);
+}
+
+function calculateReservationArticleQuantity(string $scheme, string $checkIn, string $checkOut, int $guestCount, int $roomCount, float $multiplier): float
+{
+    $multiplier = max(0.0, $multiplier);
+    if ($multiplier === 0.0) {
+        return 0.0;
+    }
+
+    $nights = calculateStayNights($checkIn, $checkOut);
+    $guestCount = max(0, $guestCount);
+    $roomCount = max(0, $roomCount);
+
+    $base = 0.0;
+    switch ($scheme) {
+        case 'per_room_per_day':
+            $base = $roomCount * $nights;
+            break;
+        case 'per_person_per_day':
+            $base = $guestCount * $nights;
+            break;
+        case 'per_day':
+            $base = $nights;
+            break;
+        case 'per_person':
+            $base = $guestCount;
+            break;
+        case 'per_stay':
+        default:
+            $base = 1;
+            break;
+    }
+
+    return max(0.0, $base * $multiplier);
+}
+
+function handleHousekeeping(string $method, array $segments): void
+{
+    $sub = $segments[1] ?? null;
+    if ($sub !== 'tasks') {
+        jsonResponse(['error' => 'Unknown housekeeping resource.'], 404);
+    }
+
+    $pdo = db();
+    $id = $segments[2] ?? null;
+
+    if ($method === 'GET') {
+        $query = 'SELECT t.*, rooms.room_number FROM tasks t LEFT JOIN rooms ON rooms.id = t.room_id';
+        $conditions = [];
+        $params = [];
+        if (isset($_GET['status'])) {
+            $conditions[] = 't.status = :status';
+            $params['status'] = $_GET['status'];
+        }
+        if ($conditions) {
+            $query .= ' WHERE ' . implode(' AND ', $conditions);
+        }
+        $query .= ' ORDER BY t.due_date IS NULL, t.due_date';
+
+        $stmt = $pdo->prepare($query);
+        $stmt->execute($params);
+        jsonResponse($stmt->fetchAll());
+    }
+
+    if ($method === 'POST') {
+        $data = parseJsonBody();
+        if (empty($data['title'])) {
+            jsonResponse(['error' => 'title is required.'], 422);
+        }
+
+        $stmt = $pdo->prepare('INSERT INTO tasks (room_id, assigned_to, title, description, status, due_date, created_at, updated_at) VALUES (:room_id, :assigned_to, :title, :description, :status, :due_date, :created_at, :updated_at)');
+        $stmt->execute([
+            'room_id' => $data['room_id'] ?? null,
+            'assigned_to' => $data['assigned_to'] ?? null,
+            'title' => $data['title'],
+            'description' => $data['description'] ?? null,
+            'status' => $data['status'] ?? 'open',
+            'due_date' => isset($data['due_date']) && validateDateTime($data['due_date']) ? $data['due_date'] : null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        jsonResponse(['id' => $pdo->lastInsertId()], 201);
+    }
+
+    if (($method === 'PUT' || $method === 'PATCH') && $id !== null) {
+        $data = parseJsonBody();
+        $fields = ['room_id', 'assigned_to', 'title', 'description', 'status', 'due_date', 'completed_at'];
+        $updates = [];
+        $params = ['id' => $id];
+        foreach ($fields as $field) {
+            if (array_key_exists($field, $data)) {
+                if (in_array($field, ['due_date', 'completed_at'], true) && $data[$field] !== null && !validateDateTime($data[$field])) {
+                    jsonResponse(['error' => sprintf('Invalid datetime for %s', $field)], 422);
+                }
+                $updates[] = sprintf('%s = :%s', $field, $field);
+                $params[$field] = $data[$field];
+            }
+        }
+        if (!$updates) {
+            jsonResponse(['error' => 'No changes supplied.'], 422);
+        }
+        $updates[] = 'updated_at = :updated_at';
+        $params['updated_at'] = now();
+        $stmt = $pdo->prepare(sprintf('UPDATE tasks SET %s WHERE id = :id', implode(', ', $updates)));
+        $stmt->execute($params);
+
+        if (isset($data['room_status']) && isset($data['room_id'])) {
+            logHousekeepingStatus((int) $data['room_id'], $data['room_status'], $data['description'] ?? null, $data['assigned_to'] ?? null);
+        }
+
+        jsonResponse(['updated' => true]);
+    }
+
+    jsonResponse(['error' => 'Unsupported method.'], 405);
+}
+
+function logHousekeepingStatus(int $roomId, string $status, ?string $notes, $userId): void
+{
+    $pdo = db();
+    $stmt = $pdo->prepare('INSERT INTO housekeeping_logs (room_id, status, notes, recorded_by, recorded_at) VALUES (:room_id, :status, :notes, :recorded_by, :recorded_at)');
+    $stmt->execute([
+        'room_id' => $roomId,
+        'status' => $status,
+        'notes' => $notes,
+        'recorded_by' => $userId,
+        'recorded_at' => now(),
+    ]);
+}
+
+function getReservationRoomIds(PDO $pdo, int $reservationId): array
+{
+    $stmt = $pdo->prepare('SELECT room_id FROM reservation_rooms WHERE reservation_id = :reservation_id');
+    $stmt->execute(['reservation_id' => $reservationId]);
+    return array_map('intval', array_column($stmt->fetchAll(), 'room_id'));
+}
+
+function normalizeReservationStatus(string $status): ?string
+{
+    $normalized = strtolower(trim($status));
+    return in_array($normalized, RESERVATION_STATUSES, true) ? $normalized : null;
+}
+
+function updateRoomsForReservationStatus(PDO $pdo, int $reservationId, string $status, ?string $notes, $recordedBy): void
+{
+    $roomIds = getReservationRoomIds($pdo, $reservationId);
+    if (!$roomIds) {
+        return;
+    }
+
+    $roomStatus = null;
+    $housekeepingStatus = null;
+
+    if (in_array($status, ['checked_in', 'paid'], true)) {
+        $roomStatus = 'occupied';
+        $housekeepingStatus = 'occupied';
+    } elseif ($status === 'checked_out') {
+        $roomStatus = 'in_cleaning';
+        $housekeepingStatus = 'in_cleaning';
+    } elseif (in_array($status, ['cancelled', 'no_show'], true)) {
+        $roomStatus = 'available';
+        $housekeepingStatus = 'available';
+    }
+
+    if ($roomStatus !== null) {
+        $updateStmt = $pdo->prepare('UPDATE rooms SET status = :status, updated_at = :updated_at WHERE id = :id');
+        foreach ($roomIds as $roomId) {
+            $updateStmt->execute([
+                'status' => $roomStatus,
+                'updated_at' => now(),
+                'id' => $roomId,
+            ]);
+        }
+    }
+
+    if ($housekeepingStatus !== null) {
+        foreach ($roomIds as $roomId) {
+            logHousekeepingStatus($roomId, $housekeepingStatus, $notes, $recordedBy);
+        }
+    }
+}
+
+function getCalendarColorSettings(PDO $pdo): array
+{
+    $stmt = $pdo->prepare("SELECT `key`, `value` FROM settings WHERE `key` LIKE 'calendar_color_%'");
+    $stmt->execute();
+    $overrides = [];
+    foreach ($stmt->fetchAll() as $row) {
+        $status = substr($row['key'], strlen('calendar_color_'));
+        if ($status && in_array($status, CALENDAR_COLOR_STATUSES, true) && is_string($row['value']) && $row['value'] !== '') {
+            $overrides[$status] = $row['value'];
+        }
+    }
+
+    return array_merge(DEFAULT_CALENDAR_COLORS, $overrides);
+}
+
+function saveCalendarColorSettings(PDO $pdo, array $colors): void
+{
+    if (!$colors) {
+        return;
+    }
+    $stmt = $pdo->prepare('INSERT INTO settings (`key`, `value`, updated_at) VALUES (:key, :value, :updated_at) ON DUPLICATE KEY UPDATE `value` = VALUES(`value`), updated_at = VALUES(updated_at)');
+    foreach ($colors as $status => $color) {
+        $stmt->execute([
+            'key' => sprintf('calendar_color_%s', $status),
+            'value' => $color,
+            'updated_at' => now(),
+        ]);
+    }
+}
+
+function clearCalendarColorSettings(PDO $pdo): void
+{
+    $pdo->prepare("DELETE FROM settings WHERE `key` LIKE 'calendar_color_%'")->execute();
+}
+
+function normalizeHexColor(string $value): ?string
+{
+    $trimmed = trim($value);
+    if ($trimmed === '') {
+        return null;
+    }
+    $trimmed = ltrim($trimmed, '#');
+    if (preg_match('/^[0-9a-fA-F]{6}$/', $trimmed) === 1) {
+        return '#' . strtoupper($trimmed);
+    }
+    if (preg_match('/^[0-9a-fA-F]{3}$/', $trimmed) === 1) {
+        return '#' . strtoupper(
+            $trimmed[0] . $trimmed[0] .
+            $trimmed[1] . $trimmed[1] .
+            $trimmed[2] . $trimmed[2]
+        );
+    }
+
+    return null;
+}
+
+function handleInvoices(string $method, array $segments): void
+{
+    $pdo = db();
+    $id = $segments[1] ?? null;
+    $action = $segments[2] ?? null;
+
+    if ($method === 'GET' && $id !== null && $action === 'pdf') {
+        outputInvoicePdf((int) $id);
+        return;
+    }
+
+    if ($method === 'GET') {
+        if ($id !== null) {
+            $invoice = getInvoiceWithRelations((int) $id);
+            if (!$invoice) {
+                jsonResponse(['error' => 'Invoice not found.'], 404);
+            }
+            jsonResponse($invoice);
+        }
+
+        $stmt = $pdo->query('SELECT * FROM invoices ORDER BY issue_date DESC');
+        jsonResponse($stmt->fetchAll());
+    }
+
+    if ($method === 'POST' && $id === null) {
+        $data = parseJsonBody();
+        if (empty($data['reservation_id'])) {
+            jsonResponse(['error' => 'reservation_id is required.'], 422);
+        }
+
+        $invoiceNumber = $data['invoice_number'] ?? generateInvoiceNumber();
+        $issueDate = $data['issue_date'] ?? date('Y-m-d');
+        $dueDate = $data['due_date'] ?? null;
+        $status = $data['status'] ?? 'issued';
+        $type = isset($data['type']) ? strtolower((string) $data['type']) : 'invoice';
+        if (!in_array($type, ['invoice', 'correction'], true)) {
+            jsonResponse(['error' => 'Unsupported invoice type.'], 422);
+        }
+
+        $parentInvoiceId = null;
+        $correctionNumber = null;
+        if ($type === 'correction') {
+            $parentInvoiceId = isset($data['parent_invoice_id']) ? (int) $data['parent_invoice_id'] : null;
+            if (!$parentInvoiceId) {
+                jsonResponse(['error' => 'parent_invoice_id is required for corrections.'], 422);
+            }
+            $correctionNumber = $data['correction_number'] ?? generateInvoiceCorrectionNumber();
+        }
+
+        $items = [];
+        if (!empty($data['items']) && is_array($data['items'])) {
+            $items = $data['items'];
+        } else {
+            $includeArticles = !isset($data['include_articles']) || filter_var($data['include_articles'], FILTER_VALIDATE_BOOLEAN);
+            try {
+                if ($type === 'correction' && $parentInvoiceId) {
+                    $items = buildCorrectionItemsFromInvoice($parentInvoiceId);
+                }
+                if (!$items) {
+                    $items = buildInvoiceItemsForReservation((int) $data['reservation_id'], $includeArticles);
+                }
+            } catch (Throwable $exception) {
+                jsonResponse(['error' => $exception->getMessage()], 422);
+            }
+        }
+
+        if (!$items) {
+            jsonResponse(['error' => 'Unable to create invoice without any items.'], 422);
+        }
+
+        $totals = calculateInvoiceTotals($items);
+
+        $stmt = $pdo->prepare('INSERT INTO invoices (reservation_id, invoice_number, correction_number, type, parent_invoice_id, issue_date, due_date, total_amount, tax_amount, status, created_at, updated_at) VALUES (:reservation_id, :invoice_number, :correction_number, :type, :parent_invoice_id, :issue_date, :due_date, :total_amount, :tax_amount, :status, :created_at, :updated_at)');
+        $stmt->execute([
+            'reservation_id' => $data['reservation_id'],
+            'invoice_number' => $invoiceNumber,
+            'correction_number' => $correctionNumber,
+            'type' => $type,
+            'parent_invoice_id' => $parentInvoiceId,
+            'issue_date' => $issueDate,
+            'due_date' => $dueDate,
+            'total_amount' => $totals['total'],
+            'tax_amount' => $totals['tax'],
+            'status' => $status,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $invoiceId = (int) $pdo->lastInsertId();
+        storeInvoiceItems($invoiceId, $items);
+
+        jsonResponse([
+            'id' => $invoiceId,
+            'invoice_number' => $invoiceNumber,
+            'correction_number' => $correctionNumber,
+            'type' => $type,
+        ], 201);
+    }
+
+    jsonResponse(['error' => 'Unsupported method.'], 405);
+}
+
+function fetchInvoiceItems(int $invoiceId): array
+{
+    $pdo = db();
+    $stmt = $pdo->prepare('SELECT * FROM invoice_items WHERE invoice_id = :invoice_id');
+    $stmt->execute(['invoice_id' => $invoiceId]);
+    return $stmt->fetchAll();
+}
+
+function storeInvoiceItems(int $invoiceId, array $items): void
+{
+    $pdo = db();
+    $stmt = $pdo->prepare('INSERT INTO invoice_items (invoice_id, description, quantity, unit_price, tax_rate, total_amount, created_at, updated_at) VALUES (:invoice_id, :description, :quantity, :unit_price, :tax_rate, :total_amount, :created_at, :updated_at)');
+    foreach ($items as $item) {
+        if (empty($item['description'])) {
+            throw new InvalidArgumentException('Each invoice item requires a description.');
+        }
+        $quantity = (float) ($item['quantity'] ?? 1);
+        $unitPrice = (float) ($item['unit_price'] ?? 0);
+        $taxRate = isset($item['tax_rate']) ? (float) $item['tax_rate'] : null;
+        $total = $quantity * $unitPrice * (1 + ($taxRate ?? 0) / 100);
+
+        $stmt->execute([
+            'invoice_id' => $invoiceId,
+            'description' => $item['description'],
+            'quantity' => $quantity,
+            'unit_price' => $unitPrice,
+            'tax_rate' => $taxRate,
+            'total_amount' => $total,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}
+
+function buildCorrectionItemsFromInvoice(int $invoiceId): array
+{
+    $items = fetchInvoiceItems($invoiceId);
+    if (!$items) {
+        return [];
+    }
+
+    $corrections = [];
+    foreach ($items as $item) {
+        $quantity = (float) ($item['quantity'] ?? 0);
+        $corrections[] = [
+            'description' => $item['description'],
+            'quantity' => $quantity > 0 ? -$quantity : $quantity,
+            'unit_price' => (float) ($item['unit_price'] ?? 0),
+            'tax_rate' => isset($item['tax_rate']) ? (float) $item['tax_rate'] : null,
+        ];
+    }
+
+    return $corrections;
+}
+
+function calculateInvoiceTotals(array $items): array
+{
+    $subtotal = 0;
+    $tax = 0;
+    foreach ($items as $item) {
+        $quantity = (float) ($item['quantity'] ?? 1);
+        $unitPrice = (float) ($item['unit_price'] ?? 0);
+        $lineSubtotal = $quantity * $unitPrice;
+        $subtotal += $lineSubtotal;
+        $taxRate = isset($item['tax_rate']) ? (float) $item['tax_rate'] : 0;
+        $tax += $lineSubtotal * ($taxRate / 100);
+    }
+
+    return [
+        'subtotal' => round($subtotal, 2),
+        'tax' => round($tax, 2),
+        'total' => round($subtotal + $tax, 2),
+    ];
+}
+
+function fetchReservationBillingSnapshot(int $reservationId): array
+{
+    $pdo = db();
+    $sql = <<<SQL
+        SELECT r.*, g.first_name, g.last_name, g.email, g.phone, g.address, g.city, g.country, g.company_id,
+               c.name AS company_name, c.address AS company_address, c.city AS company_city, c.country AS company_country,
+               c.email AS company_email, c.phone AS company_phone,
+               rp.base_price AS rate_plan_base_price, rp.currency AS rate_plan_currency
+        FROM reservations r
+        JOIN guests g ON g.id = r.guest_id
+        LEFT JOIN companies c ON c.id = g.company_id
+        LEFT JOIN rate_plans rp ON rp.id = r.rate_plan_id
+        WHERE r.id = :id
+    SQL;
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute(['id' => $reservationId]);
+    $reservation = $stmt->fetch();
+    if (!$reservation) {
+        throw new InvalidArgumentException('Reservation not found for invoice generation.');
+    }
+
+    $reservation['rooms'] = fetchReservationRooms($reservationId);
+    $reservation['room_requests'] = fetchReservationRoomRequests($reservationId, $pdo);
+    $reservation['articles'] = fetchReservationArticles($reservationId);
+
+    return $reservation;
+}
+
+function determineNightlyRate(array $room, array $reservation, int $nights): float
+{
+    $nightlyRate = isset($room['nightly_rate']) ? (float) $room['nightly_rate'] : 0.0;
+    if ($nightlyRate <= 0 && isset($reservation['rate_plan_base_price'])) {
+        $nightlyRate = (float) $reservation['rate_plan_base_price'];
+    }
+    if ($nightlyRate <= 0 && isset($room['room_type_base_rate'])) {
+        $nightlyRate = (float) $room['room_type_base_rate'];
+    }
+    if ($nightlyRate <= 0 && isset($reservation['total_amount'])) {
+        $roomCount = max(1, count($reservation['rooms'] ?? []));
+        $nightCount = max(1, $nights);
+        $nightlyRate = ((float) $reservation['total_amount']) / ($roomCount * $nightCount);
+    }
+
+    return max(0.0, $nightlyRate);
+}
+
+function fetchInvoicesForReservation(int $reservationId): array
+{
+    $pdo = db();
+    $stmt = $pdo->prepare('SELECT * FROM invoices WHERE reservation_id = :id ORDER BY created_at DESC, id DESC');
+    $stmt->execute(['id' => $reservationId]);
+    $invoices = $stmt->fetchAll();
+    foreach ($invoices as &$invoice) {
+        $invoice['items'] = fetchInvoiceItems((int) $invoice['id']);
+    }
+    unset($invoice);
+
+    return $invoices;
+}
+
+function findLatestInvoiceForReservation(int $reservationId): ?array
+{
+    $invoices = fetchInvoicesForReservation($reservationId);
+    return $invoices[0] ?? null;
+}
+
+function createReservationInvoice(int $reservationId, array $payload = []): array
+{
+    $pdo = db();
+    $stmt = $pdo->prepare('SELECT id FROM reservations WHERE id = :id');
+    $stmt->execute(['id' => $reservationId]);
+    if ($stmt->fetchColumn() === false) {
+        throw new InvalidArgumentException('Reservierung wurde nicht gefunden.');
+    }
+
+    $includeArticles = !isset($payload['include_articles']) || filter_var($payload['include_articles'], FILTER_VALIDATE_BOOLEAN);
+    $items = buildInvoiceItemsForReservation($reservationId, $includeArticles);
+    if (!$items) {
+        throw new InvalidArgumentException('Für diese Reservierung sind keine abrechenbaren Posten hinterlegt.');
+    }
+
+    $invoiceNumber = $payload['invoice_number'] ?? generateInvoiceNumber();
+    $issueDate = $payload['issue_date'] ?? date('Y-m-d');
+    $dueDate = $payload['due_date'] ?? null;
+    $status = $payload['status'] ?? 'issued';
+
+    $totals = calculateInvoiceTotals($items);
+
+    $pdo->beginTransaction();
+    try {
+        $stmt = $pdo->prepare('INSERT INTO invoices (reservation_id, invoice_number, correction_number, type, parent_invoice_id, issue_date, due_date, total_amount, tax_amount, status, created_at, updated_at) VALUES (:reservation_id, :invoice_number, :correction_number, :type, :parent_invoice_id, :issue_date, :due_date, :total_amount, :tax_amount, :status, :created_at, :updated_at)');
+        $stmt->execute([
+            'reservation_id' => $reservationId,
+            'invoice_number' => $invoiceNumber,
+            'correction_number' => null,
+            'type' => 'invoice',
+            'parent_invoice_id' => null,
+            'issue_date' => $issueDate,
+            'due_date' => $dueDate,
+            'total_amount' => $totals['total'],
+            'tax_amount' => $totals['tax'],
+            'status' => $status,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $invoiceId = (int) $pdo->lastInsertId();
+        storeInvoiceItems($invoiceId, $items);
+
+        $pdo->commit();
+
+        $invoice = getInvoiceWithRelations($invoiceId);
+        return $invoice ?? ['id' => $invoiceId, 'invoice_number' => $invoiceNumber];
+    } catch (Throwable $exception) {
+        $pdo->rollBack();
+        throw $exception;
+    }
+}
+
+function payReservationInvoice(int $reservationId, array $payload = []): array
+{
+    $pdo = db();
+    $invoice = findLatestInvoiceForReservation($reservationId);
+    if (!$invoice) {
+        throw new InvalidArgumentException('Es liegt noch keine Rechnung für diese Reservierung vor.');
+    }
+
+    if (($invoice['status'] ?? '') === 'paid') {
+        return ['invoice' => $invoice, 'message' => 'Rechnung bereits als bezahlt verbucht.'];
+    }
+
+    $amount = isset($payload['amount']) ? (float) $payload['amount'] : (float) ($invoice['total_amount'] ?? 0);
+    if ($amount <= 0) {
+        throw new InvalidArgumentException('Ungültiger Zahlungsbetrag.');
+    }
+
+    $method = $payload['method'] ?? 'cash';
+    $paidAt = $payload['paid_at'] ?? now();
+    $currency = $payload['currency'] ?? ($invoice['reservation_currency'] ?? 'EUR');
+    $notes = $payload['notes'] ?? null;
+    $recordedBy = $payload['recorded_by'] ?? null;
+
+    $pdo->beginTransaction();
+    try {
+        $stmt = $pdo->prepare('INSERT INTO payments (invoice_id, method, amount, currency, paid_at, reference, notes, created_at, updated_at) VALUES (:invoice_id, :method, :amount, :currency, :paid_at, :reference, :notes, :created_at, :updated_at)');
+        $stmt->execute([
+            'invoice_id' => $invoice['id'],
+            'method' => $method,
+            'amount' => $amount,
+            'currency' => $currency,
+            'paid_at' => $paidAt,
+            'reference' => $payload['reference'] ?? null,
+            'notes' => $notes,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $update = $pdo->prepare('UPDATE invoices SET status = :status, updated_at = :updated_at WHERE id = :id');
+        $update->execute([
+            'status' => 'paid',
+            'updated_at' => now(),
+            'id' => $invoice['id'],
+        ]);
+
+        applyReservationStatusChange($pdo, $reservationId, 'paid', $notes, $recordedBy);
+
+        $pdo->commit();
+    } catch (Throwable $exception) {
+        $pdo->rollBack();
+        throw $exception;
+    }
+
+    $updatedInvoice = getInvoiceWithRelations((int) $invoice['id']);
+
+    return [
+        'invoice' => $updatedInvoice ?? $invoice,
+        'payment' => [
+            'invoice_id' => $invoice['id'],
+            'amount' => $amount,
+            'method' => $method,
+            'currency' => $currency,
+            'paid_at' => $paidAt,
+        ],
+    ];
+}
+
+function buildInvoiceItemsForReservation(int $reservationId, bool $includeArticles = true): array
+{
+    $reservation = fetchReservationBillingSnapshot($reservationId);
+    $nights = calculateStayNights((string) $reservation['check_in_date'], (string) $reservation['check_out_date']);
+    $nights = max(1, $nights);
+
+    $items = [];
+
+    foreach ($reservation['rooms'] as $room) {
+        $rate = determineNightlyRate($room, $reservation, $nights);
+        if ($rate <= 0) {
+            continue;
+        }
+        $labelParts = [];
+        $labelParts[] = $room['room_number'] ?? ('Zimmer ' . ($room['room_id'] ?? ''));
+        if (!empty($room['room_type_name'])) {
+            $labelParts[] = $room['room_type_name'];
+        }
+        $roomLabel = implode(' – ', array_filter($labelParts));
+        $items[] = [
+            'description' => sprintf('Zimmer %s · %d Nacht%s', $roomLabel, $nights, $nights === 1 ? '' : 'e'),
+            'quantity' => $nights,
+            'unit_price' => round($rate, 2),
+            'tax_rate' => GERMAN_VAT_REDUCED,
+        ];
+    }
+
+    if ($includeArticles) {
+        foreach ($reservation['articles'] as $article) {
+            $quantity = (float) ($article['quantity'] ?? 0);
+            $unitPrice = isset($article['unit_price']) ? (float) $article['unit_price'] : 0.0;
+            if ($quantity <= 0 || $unitPrice < 0) {
+                continue;
+            }
+            $description = $article['description'] ?? ($article['article_name'] ?? 'Zusatzleistung');
+            $taxRate = isset($article['tax_rate']) ? (float) $article['tax_rate'] : GERMAN_VAT_STANDARD;
+            $items[] = [
+                'description' => $description,
+                'quantity' => round($quantity, 2),
+                'unit_price' => round($unitPrice, 2),
+                'tax_rate' => $taxRate,
+            ];
+        }
+    }
+
+    return $items;
+}
+
+function getInvoiceWithRelations(int $invoiceId): ?array
+{
+    $pdo = db();
+    $sql = <<<SQL
+        SELECT i.*, r.confirmation_number, r.check_in_date, r.check_out_date, r.adults, r.children, r.currency AS reservation_currency,
+               g.first_name, g.last_name, g.email, g.phone, g.address, g.city, g.country,
+               c.name AS company_name, c.address AS company_address, c.city AS company_city, c.country AS company_country,
+               c.email AS company_email, c.phone AS company_phone
+        FROM invoices i
+        JOIN reservations r ON r.id = i.reservation_id
+        JOIN guests g ON g.id = r.guest_id
+        LEFT JOIN companies c ON c.id = g.company_id
+        WHERE i.id = :id
+    SQL;
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute(['id' => $invoiceId]);
+    $invoice = $stmt->fetch();
+    if (!$invoice) {
+        return null;
+    }
+    $invoice['items'] = fetchInvoiceItems($invoiceId);
+
+    return $invoice;
+}
+
+function outputInvoicePdf(int $invoiceId): void
+{
+    $invoice = getInvoiceWithRelations($invoiceId);
+    if (!$invoice) {
+        jsonResponse(['error' => 'Invoice not found.'], 404);
+    }
+
+    require_once __DIR__ . '/../lib/fpdf.php';
+
+    $pdf = new FPDF('P', 'mm', 'A4');
+    $pdf->SetMargins(15, 20, 15);
+    $pdf->AddPage();
+
+    $logo = getInvoiceLogoDescriptor();
+    if ($logo && is_file($logo['path'])) {
+        $pdf->Image($logo['path'], 15, 15, 40);
+        $pdf->SetY(20);
+    }
+
+    $pdf->SetFont('Arial', 'B', 16);
+    $pdf->Cell(0, 10, pdfText('Rechnung'), 0, 1, 'R');
+
+    $pdf->SetFont('Arial', '', 11);
+    $pdf->Cell(0, 6, pdfText('Rechnungsnummer: ' . ($invoice['invoice_number'] ?? '')), 0, 1, 'R');
+    if (!empty($invoice['issue_date'])) {
+        $pdf->Cell(0, 6, pdfText('Ausgestellt am: ' . formatGermanDate($invoice['issue_date'])), 0, 1, 'R');
+    }
+    if (!empty($invoice['due_date'])) {
+        $pdf->Cell(0, 6, pdfText('Fällig am: ' . formatGermanDate($invoice['due_date'])), 0, 1, 'R');
+    }
+
+    $pdf->Ln(6);
+
+    $guestName = trim(($invoice['first_name'] ?? '') . ' ' . ($invoice['last_name'] ?? ''));
+    $recipientLines = array_filter([
+        $invoice['company_name'] ?? null,
+        $guestName ?: null,
+        $invoice['company_address'] ?? $invoice['address'] ?? null,
+        trim(($invoice['company_city'] ?? $invoice['city'] ?? '') . ' ' . ($invoice['company_country'] ?? $invoice['country'] ?? '')),
+    ]);
+
+    foreach ($recipientLines as $line) {
+        $pdf->Cell(0, 6, pdfText($line), 0, 1);
+    }
+
+    $pdf->Ln(4);
+
+    if (!empty($invoice['check_in_date']) || !empty($invoice['check_out_date'])) {
+        $stay = sprintf('%s – %s', formatGermanDate($invoice['check_in_date']), formatGermanDate($invoice['check_out_date']));
+        $pdf->Cell(0, 6, pdfText('Aufenthalt: ' . $stay), 0, 1);
+    }
+    if (!empty($invoice['confirmation_number'])) {
+        $pdf->Cell(0, 6, pdfText('Bestätigungsnummer: ' . $invoice['confirmation_number']), 0, 1);
+    }
+
+    $pdf->Ln(6);
+
+    $pdf->SetFont('Arial', 'B', 11);
+    $widths = [90, 20, 30, 20, 30];
+    $headers = ['Beschreibung', 'Menge', 'Einzelpreis', 'MwSt', 'Gesamt'];
+    $pdf->SetFillColor(240, 240, 240);
+    foreach ($headers as $index => $header) {
+        $align = $index === 0 ? 'L' : 'R';
+        $pdf->Cell($widths[$index], 8, pdfText($header), 1, $index === count($headers) - 1 ? 1 : 0, $align, true);
+    }
+
+    $pdf->SetFont('Arial', '', 10);
+    $currency = $invoice['reservation_currency'] ?? 'EUR';
+    foreach ($invoice['items'] as $item) {
+        $quantity = (float) ($item['quantity'] ?? 0);
+        $unit = (float) ($item['unit_price'] ?? 0);
+        $taxRate = isset($item['tax_rate']) ? (float) $item['tax_rate'] : 0.0;
+        $lineTotal = isset($item['total_amount']) ? (float) $item['total_amount'] : ($quantity * $unit * (1 + $taxRate / 100));
+        $startX = $pdf->GetX();
+        $startY = $pdf->GetY();
+        $desc = pdfText($item['description'] ?? '');
+        $pdf->MultiCell($widths[0], 6, $desc, 1, 'L');
+        $currentY = $pdf->GetY();
+        $rowHeight = $currentY - $startY;
+        $pdf->SetXY($startX + $widths[0], $startY);
+        $pdf->Cell($widths[1], $rowHeight, pdfText(number_format($quantity, 2, ',', '.')), 1, 0, 'R');
+        $pdf->Cell($widths[2], $rowHeight, pdfText(number_format($unit, 2, ',', '.') . ' ' . $currency), 1, 0, 'R');
+        $pdf->Cell($widths[3], $rowHeight, pdfText(number_format($taxRate, 1, ',', '.') . '%'), 1, 0, 'R');
+        $pdf->Cell($widths[4], $rowHeight, pdfText(number_format($lineTotal, 2, ',', '.') . ' ' . $currency), 1, 0, 'R');
+        $pdf->SetY($currentY);
+    }
+
+    $pdf->Ln(2);
+
+    $totals = calculateInvoiceTotals($invoice['items']);
+    $taxTotal = isset($invoice['tax_amount']) ? (float) $invoice['tax_amount'] : $totals['tax'];
+    $totalAmount = isset($invoice['total_amount']) ? (float) $invoice['total_amount'] : $totals['total'];
+    $subtotal = $totalAmount - $taxTotal;
+
+    $pdf->SetFont('Arial', 'B', 11);
+    $pdf->Cell(array_sum($widths) - $widths[4], 8, '', 0, 0);
+    $pdf->Cell($widths[4], 8, pdfText('Zwischensumme: ' . number_format($subtotal, 2, ',', '.') . ' ' . $currency), 0, 1, 'R');
+    $pdf->Cell(array_sum($widths) - $widths[4], 8, '', 0, 0);
+    $pdf->Cell($widths[4], 8, pdfText('MwSt: ' . number_format($taxTotal, 2, ',', '.') . ' ' . $currency), 0, 1, 'R');
+    $pdf->Cell(array_sum($widths) - $widths[4], 8, '', 0, 0);
+    $pdf->Cell($widths[4], 8, pdfText('Gesamt: ' . number_format($totalAmount, 2, ',', '.') . ' ' . $currency), 0, 1, 'R');
+
+    header('Content-Type: application/pdf');
+    $filename = sprintf('Rechnung-%s.pdf', $invoice['invoice_number'] ?? $invoiceId);
+    header('Content-Disposition: inline; filename="' . $filename . '"');
+    $pdf->Output('I', $filename);
+    exit;
+}
+
+function handlePayments(string $method, array $segments): void
+{
+    $pdo = db();
+
+    if ($method === 'GET') {
+        $stmt = $pdo->query('SELECT payments.*, invoices.invoice_number FROM payments JOIN invoices ON invoices.id = payments.invoice_id ORDER BY paid_at DESC');
+        jsonResponse($stmt->fetchAll());
+    }
+
+    if ($method === 'POST') {
+        $data = parseJsonBody();
+        foreach (['invoice_id', 'method', 'amount'] as $field) {
+            if (empty($data[$field])) {
+                jsonResponse(['error' => sprintf('%s is required.', $field)], 422);
+            }
+        }
+
+        $stmt = $pdo->prepare('INSERT INTO payments (invoice_id, method, amount, currency, paid_at, reference, notes, created_at, updated_at) VALUES (:invoice_id, :method, :amount, :currency, :paid_at, :reference, :notes, :created_at, :updated_at)');
+        $stmt->execute([
+            'invoice_id' => $data['invoice_id'],
+            'method' => $data['method'],
+            'amount' => $data['amount'],
+            'currency' => $data['currency'] ?? 'EUR',
+            'paid_at' => $data['paid_at'] ?? now(),
+            'reference' => $data['reference'] ?? null,
+            'notes' => $data['notes'] ?? null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        jsonResponse(['id' => $pdo->lastInsertId()], 201);
+    }
+
+    jsonResponse(['error' => 'Unsupported method.'], 405);
+}
+
+function handleReports(string $method, array $segments): void
+{
+    if ($method !== 'GET') {
+        jsonResponse(['error' => 'Only GET supported for reports.'], 405);
+    }
+
+    $type = $segments[1] ?? null;
+    if ($type === 'occupancy') {
+        $start = $_GET['start'] ?? date('Y-m-d');
+        $end = $_GET['end'] ?? $start;
+        if (!validateDate($start) || !validateDate($end)) {
+            jsonResponse(['error' => 'start and end must be valid dates (Y-m-d).'], 422);
+        }
+        jsonResponse(buildOccupancyReport($start, $end));
+    }
+
+    if ($type === 'revenue') {
+        $start = $_GET['start'] ?? date('Y-m-01');
+        $end = $_GET['end'] ?? date('Y-m-t');
+        if (!validateDate($start) || !validateDate($end)) {
+            jsonResponse(['error' => 'start and end must be valid dates (Y-m-d).'], 422);
+        }
+        jsonResponse(buildRevenueReport($start, $end));
+    }
+
+    if ($type === 'forecast') {
+        $start = $_GET['start'] ?? date('Y-m-d');
+        $end = $_GET['end'] ?? date('Y-m-d', strtotime('+30 days'));
+        if (!validateDate($start) || !validateDate($end)) {
+            jsonResponse(['error' => 'start and end must be valid dates (Y-m-d).'], 422);
+        }
+        jsonResponse(buildForecastReport($start, $end));
+    }
+
+    jsonResponse(['error' => 'Unknown report type.'], 404);
+}
+
+function buildOccupancyReport(string $start, string $end): array
+{
+    $pdo = db();
+    $stmt = $pdo->query('SELECT COUNT(*) FROM rooms');
+    $totalRooms = (int) $stmt->fetchColumn();
+
+    $period = new DatePeriod(new DateTimeImmutable($start), new DateInterval('P1D'), (new DateTimeImmutable($end))->modify('+1 day'));
+    $report = [];
+    foreach ($period as $date) {
+        $formatted = $date->format('Y-m-d');
+        $stmt = $pdo->prepare('SELECT COUNT(DISTINCT rr.room_id) FROM reservation_rooms rr JOIN reservations r ON rr.reservation_id = r.id WHERE r.status IN (\'confirmed\', \'checked_in\', \'paid\') AND :date >= r.check_in_date AND :date < r.check_out_date');
+        $stmt->execute(['date' => $formatted]);
+        $occupied = (int) $stmt->fetchColumn();
+        $report[] = [
+            'date' => $formatted,
+            'occupied_rooms' => $occupied,
+            'available_rooms' => $totalRooms,
+            'occupancy_rate' => $totalRooms === 0 ? 0 : round(($occupied / $totalRooms) * 100, 2),
+        ];
+    }
+
+    return $report;
+}
+
+function buildRevenueReport(string $start, string $end): array
+{
+    $pdo = db();
+    $stmt = $pdo->prepare('SELECT SUM(total_amount) as invoice_total, SUM(tax_amount) as tax_total FROM invoices WHERE issue_date BETWEEN :start AND :end');
+    $stmt->execute(['start' => $start, 'end' => $end]);
+    $invoiceTotals = $stmt->fetch() ?: ['invoice_total' => 0, 'tax_total' => 0];
+
+    $stmt = $pdo->prepare('SELECT method, SUM(amount) as total_amount FROM payments WHERE paid_at BETWEEN :start_dt AND :end_dt GROUP BY method');
+    $stmt->execute([
+        'start_dt' => $start . ' 00:00:00',
+        'end_dt' => $end . ' 23:59:59',
+    ]);
+    $payments = $stmt->fetchAll();
+
+    return [
+        'period' => ['start' => $start, 'end' => $end],
+        'invoices' => $invoiceTotals,
+        'payments' => $payments,
+    ];
+}
+
+function buildForecastReport(string $start, string $end): array
+{
+    $pdo = db();
+    $stmt = $pdo->prepare('SELECT r.check_in_date, r.check_out_date, COUNT(rr.room_id) as rooms, COALESCE(r.total_amount, 0) as total_amount FROM reservations r LEFT JOIN reservation_rooms rr ON rr.reservation_id = r.id WHERE r.status IN (\'tentative\', \'confirmed\', \'paid\') AND r.check_in_date BETWEEN :start AND :end GROUP BY r.id');
+    $stmt->execute(['start' => $start, 'end' => $end]);
+    $rows = $stmt->fetchAll();
+
+    $totalRooms = array_sum(array_column($rows, 'rooms'));
+    $totalRevenue = array_sum(array_column($rows, 'total_amount'));
+
+    return [
+        'period' => ['start' => $start, 'end' => $end],
+        'expected_rooms' => $totalRooms,
+        'expected_revenue' => $totalRevenue,
+        'reservations' => $rows,
+    ];
+}
+
+function handleUsers(string $method, array $segments): void
+{
+    $pdo = db();
+    $id = $segments[1] ?? null;
+
+    if ($method === 'GET') {
+        $stmt = $pdo->query('SELECT u.id, u.name, u.email, u.created_at, u.updated_at FROM users u ORDER BY u.name');
+        $users = $stmt->fetchAll();
+        foreach ($users as &$user) {
+            $stmtRoles = $pdo->prepare('SELECT r.id, r.name FROM roles r JOIN role_user ru ON ru.role_id = r.id WHERE ru.user_id = :user_id');
+            $stmtRoles->execute(['user_id' => $user['id']]);
+            $user['roles'] = $stmtRoles->fetchAll();
+        }
+        jsonResponse($users);
+    }
+
+    if ($method === 'POST' && $id === null) {
+        $data = parseJsonBody();
+        foreach (['name', 'email', 'password'] as $field) {
+            if (empty($data[$field])) {
+                jsonResponse(['error' => sprintf('%s is required.', $field)], 422);
+            }
+        }
+
+        $stmt = $pdo->prepare('INSERT INTO users (name, email, password, created_at, updated_at) VALUES (:name, :email, :password, :created_at, :updated_at)');
+        $stmt->execute([
+            'name' => $data['name'],
+            'email' => $data['email'],
+            'password' => password_hash($data['password'], PASSWORD_BCRYPT),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $userId = (int) $pdo->lastInsertId();
+        if (!empty($data['role_ids']) && is_array($data['role_ids'])) {
+            assignRolesToUser($userId, $data['role_ids']);
+        }
+
+        jsonResponse(['id' => $userId], 201);
+    }
+
+    if ($method === 'POST' && $id !== null && ($segments[2] ?? null) === 'roles') {
+        $data = parseJsonBody();
+        assignRolesToUser((int) $id, $data['role_ids'] ?? []);
+        jsonResponse(['updated' => true]);
+    }
+
+    jsonResponse(['error' => 'Unsupported method.'], 405);
+}
+
+function assignRolesToUser(int $userId, array $roleIds): void
+{
+    $pdo = db();
+    $pdo->prepare('DELETE FROM role_user WHERE user_id = :user_id')->execute(['user_id' => $userId]);
+    $stmt = $pdo->prepare('INSERT INTO role_user (user_id, role_id, assigned_at) VALUES (:user_id, :role_id, :assigned_at)');
+    foreach ($roleIds as $roleId) {
+        $stmt->execute([
+            'user_id' => $userId,
+            'role_id' => $roleId,
+            'assigned_at' => now(),
+        ]);
+    }
+}
+
+function handleRoles(string $method, array $segments): void
+{
+    $pdo = db();
+    $id = $segments[1] ?? null;
+
+    if ($method === 'GET') {
+        $stmt = $pdo->query('SELECT * FROM roles ORDER BY name');
+        jsonResponse($stmt->fetchAll());
+    }
+
+    if ($method === 'POST' && $id === null) {
+        $data = parseJsonBody();
+        if (empty($data['name'])) {
+            jsonResponse(['error' => 'name is required.'], 422);
+        }
+
+        $stmt = $pdo->prepare('INSERT INTO roles (name, description, created_at, updated_at) VALUES (:name, :description, :created_at, :updated_at)');
+        $stmt->execute([
+            'name' => $data['name'],
+            'description' => $data['description'] ?? null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        jsonResponse(['id' => $pdo->lastInsertId()], 201);
+    }
+
+    if ($method === 'POST' && $id !== null && ($segments[2] ?? null) === 'permissions') {
+        $data = parseJsonBody();
+        assignPermissionsToRole((int) $id, $data['permission_ids'] ?? []);
+        jsonResponse(['updated' => true]);
+    }
+
+    jsonResponse(['error' => 'Unsupported method.'], 405);
+}
+
+function assignPermissionsToRole(int $roleId, array $permissionIds): void
+{
+    $pdo = db();
+    $pdo->prepare('DELETE FROM permission_role WHERE role_id = :role_id')->execute(['role_id' => $roleId]);
+    $stmt = $pdo->prepare('INSERT INTO permission_role (permission_id, role_id, granted_at) VALUES (:permission_id, :role_id, :granted_at)');
+    foreach ($permissionIds as $permissionId) {
+        $stmt->execute([
+            'permission_id' => $permissionId,
+            'role_id' => $roleId,
+            'granted_at' => now(),
+        ]);
+    }
+}
+
+function handlePermissions(string $method, array $segments): void
+{
+    $pdo = db();
+
+    if ($method === 'GET') {
+        $stmt = $pdo->query('SELECT * FROM permissions ORDER BY name');
+        jsonResponse($stmt->fetchAll());
+    }
+
+    if ($method === 'POST') {
+        $data = parseJsonBody();
+        if (empty($data['name'])) {
+            jsonResponse(['error' => 'name is required.'], 422);
+        }
+
+        $stmt = $pdo->prepare('INSERT INTO permissions (name, description, created_at, updated_at) VALUES (:name, :description, :created_at, :updated_at)');
+        $stmt->execute([
+            'name' => $data['name'],
+            'description' => $data['description'] ?? null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        jsonResponse(['id' => $pdo->lastInsertId()], 201);
+    }
+
+    jsonResponse(['error' => 'Unsupported method.'], 405);
+}
+
+function handleIntegrations(string $method, array $segments): void
+{
+    if ($method !== 'GET') {
+        jsonResponse(['error' => 'Only GET supported for integrations.'], 405);
+    }
+
+    $type = $segments[1] ?? null;
+    if ($type === null) {
+        jsonResponse([
+            'channel_manager' => ['status' => 'not_connected', 'providers' => ['booking.com', 'expedia']],
+            'door_lock' => ['status' => 'not_configured'],
+            'pos' => ['status' => 'not_configured'],
+            'accounting' => ['status' => 'not_configured'],
+        ]);
+    }
+
+    switch ($type) {
+        case 'channel-manager':
+            jsonResponse(['status' => 'not_connected', 'message' => 'No channel manager connected yet. Configure credentials to enable automatic distribution.']);
+        case 'door-locks':
+            jsonResponse(['status' => 'not_configured', 'message' => 'Door lock integration placeholder.']);
+        case 'pos':
+            jsonResponse(['status' => 'not_configured', 'message' => 'POS integration placeholder.']);
+        case 'accounting':
+            jsonResponse(['status' => 'not_configured', 'message' => 'Accounting export placeholder.']);
+    }
+
+    jsonResponse(['error' => 'Unknown integration.'], 404);
+}
+
+function handleGuestPortal(string $method, array $segments): void
+{
+    $sub = $segments[1] ?? null;
+    if ($sub !== 'reservations') {
+        jsonResponse(['error' => 'Unsupported guest portal resource.'], 404);
+    }
+
+    $confirmation = $segments[2] ?? null;
+    if ($confirmation === null) {
+        jsonResponse(['error' => 'Confirmation number required.'], 422);
+    }
+
+    $pdo = db();
+    $stmt = $pdo->prepare('SELECT r.*, g.first_name, g.last_name, g.email, g.company_id, c.name AS company_name FROM reservations r JOIN guests g ON g.id = r.guest_id LEFT JOIN companies c ON c.id = g.company_id WHERE r.confirmation_number = :confirmation');
+    $stmt->execute(['confirmation' => $confirmation]);
+    $reservation = $stmt->fetch();
+    if (!$reservation) {
+        jsonResponse(['error' => 'Reservation not found.'], 404);
+    }
+
+    $action = $segments[3] ?? null;
+    if ($method === 'GET' && $action === null) {
+        $reservation['rooms'] = fetchReservationRooms((int) $reservation['id']);
+        $reservation['documents'] = fetchReservationDocuments((int) $reservation['id']);
+        jsonResponse($reservation);
+    }
+
+    if ($method === 'POST' && $action === 'check-in') {
+        $data = parseJsonBody();
+        $data['notes'] = $data['notes'] ?? 'Guest self check-in';
+        handleReservationStatusChange((int) $reservation['id'], 'checked_in', $data);
+        return;
+    }
+
+    if ($method === 'POST' && $action === 'documents') {
+        $data = parseJsonBody();
+        addReservationDocument((int) $reservation['id'], $data);
+        return;
+    }
+
+    if ($method === 'POST' && $action === 'upsell') {
+        $data = parseJsonBody();
+        if (empty($data['service_type'])) {
+            jsonResponse(['error' => 'service_type is required.'], 422);
+        }
+        $stmt = $pdo->prepare('INSERT INTO service_orders (reservation_id, service_type, status, notes, created_at, updated_at) VALUES (:reservation_id, :service_type, :status, :notes, :created_at, :updated_at)');
+        $stmt->execute([
+            'reservation_id' => $reservation['id'],
+            'service_type' => $data['service_type'],
+            'status' => 'open',
+            'notes' => $data['notes'] ?? null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        jsonResponse(['service_order_id' => $pdo->lastInsertId()], 201);
+        return;
+    }
+
+    jsonResponse(['error' => 'Unsupported guest portal action.'], 405);
+}
+
+function handleSettings(string $method, array $segments): void
+{
+    $pdo = db();
+    $subresource = $segments[1] ?? null;
+
+    if ($subresource === null) {
+        if ($method === 'GET') {
+            jsonResponse([
+                'resources' => ['calendar-colors', 'invoice-logo'],
+            ]);
+        }
+        jsonResponse(['error' => 'Unsupported method.'], 405);
+    }
+
+    if ($subresource === 'calendar-colors') {
+        if ($method === 'GET') {
+            jsonResponse(['colors' => getCalendarColorSettings($pdo)]);
+        }
+
+        if ($method === 'DELETE') {
+            clearCalendarColorSettings($pdo);
+            jsonResponse(['colors' => getCalendarColorSettings($pdo)]);
+        }
+
+        if ($method === 'POST' || $method === 'PUT' || $method === 'PATCH') {
+            $data = parseJsonBody();
+            $payload = [];
+            if (isset($data['colors']) && is_array($data['colors'])) {
+                $payload = $data['colors'];
+            } elseif (is_array($data)) {
+                $payload = $data;
+            }
+
+            if (!$payload) {
+                jsonResponse(['error' => 'No colors supplied.'], 422);
+            }
+
+            $normalized = [];
+            foreach ($payload as $status => $color) {
+                if (!in_array($status, CALENDAR_COLOR_STATUSES, true)) {
+                    continue;
+                }
+                $normalizedColor = normalizeHexColor((string) $color);
+                if ($normalizedColor === null) {
+                    jsonResponse(['error' => sprintf('Invalid colour value for %s', $status)], 422);
+                }
+                $normalized[$status] = $normalizedColor;
+            }
+
+            if (!$normalized) {
+                jsonResponse(['error' => 'No valid colours supplied.'], 422);
+            }
+
+            saveCalendarColorSettings($pdo, $normalized);
+            jsonResponse(['colors' => getCalendarColorSettings($pdo)]);
+        }
+
+        jsonResponse(['error' => 'Unsupported method.'], 405);
+    }
+
+    if ($subresource === 'invoice-logo') {
+        if ($method === 'GET') {
+            $descriptor = getInvoiceLogoDescriptor();
+            if (!$descriptor) {
+                jsonResponse(['logo' => null]);
+            }
+            $binary = @file_get_contents($descriptor['path']);
+            if ($binary === false) {
+                jsonResponse(['logo' => null]);
+            }
+            $dataUrl = sprintf('data:%s;base64,%s', $descriptor['mime'], base64_encode($binary));
+            jsonResponse([
+                'logo' => $dataUrl,
+                'updated_at' => $descriptor['updated_at'] ?? null,
+            ]);
+        }
+
+        if ($method === 'DELETE') {
+            deleteInvoiceLogo();
+            jsonResponse(['logo' => null]);
+        }
+
+        if ($method === 'POST' || $method === 'PUT') {
+            $data = parseJsonBody();
+            if (!empty($data['remove'])) {
+                deleteInvoiceLogo();
+                jsonResponse(['logo' => null]);
+            }
+            if (empty($data['image']) || !is_string($data['image'])) {
+                jsonResponse(['error' => 'image payload is required.'], 422);
+            }
+            try {
+                $descriptor = saveInvoiceLogoImage($data['image']);
+            } catch (Throwable $exception) {
+                jsonResponse(['error' => $exception->getMessage()], 422);
+            }
+            $binary = file_get_contents($descriptor['path']);
+            $dataUrl = sprintf('data:%s;base64,%s', $descriptor['mime'], base64_encode($binary));
+            jsonResponse([
+                'logo' => $dataUrl,
+                'updated_at' => $descriptor['updated_at'] ?? null,
+            ]);
+        }
+
+        jsonResponse(['error' => 'Unsupported method.'], 405);
+    }
+
+    jsonResponse(['error' => 'Unknown settings resource.'], 404);
+}
+
+function generateReservationNumber(): string
+{
+    return formatSequenceNumber('RES-', nextSequenceValue('sequence_reservation'));
+}
+
+function generateConfirmationNumber(): string
+{
+    return generateReservationNumber();
+}
+
+function generateInvoiceNumber(): string
+{
+    return formatSequenceNumber('INV-', nextSequenceValue('sequence_invoice'));
+}
+
+function generateInvoiceCorrectionNumber(): string
+{
+    return formatSequenceNumber('COR-', nextSequenceValue('sequence_invoice_correction'));
+}
+
+function nextSequenceValue(string $key, int $start = 1): int
+{
+    $pdo = db();
+    $pdo->beginTransaction();
+    try {
+        $stmt = $pdo->prepare('SELECT `value` FROM settings WHERE `key` = :key FOR UPDATE');
+        $stmt->execute(['key' => $key]);
+        $current = $stmt->fetchColumn();
+        if ($current === false) {
+            $next = $start;
+            $insert = $pdo->prepare('INSERT INTO settings (`key`, `value`, created_at, updated_at) VALUES (:key, :value, :created_at, :updated_at)');
+            $insert->execute([
+                'key' => $key,
+                'value' => (string) $next,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        } else {
+            $currentValue = (int) $current;
+            $next = max($start, $currentValue + 1);
+            $update = $pdo->prepare('UPDATE settings SET `value` = :value, updated_at = :updated_at WHERE `key` = :key');
+            $update->execute([
+                'value' => (string) $next,
+                'updated_at' => now(),
+                'key' => $key,
+            ]);
+        }
+
+        $pdo->commit();
+
+        return $next;
+    } catch (Throwable $exception) {
+        $pdo->rollBack();
+        throw $exception;
+    }
+}
+
+function formatSequenceNumber(string $prefix, int $number, int $padding = 6): string
+{
+    $padding = max(1, $padding);
+    return sprintf('%s%0' . $padding . 'd', $prefix, $number);
+}
+
+function pdfText(string $value): string
+{
+    $converted = @iconv('UTF-8', 'ISO-8859-1//TRANSLIT', $value);
+    if ($converted === false) {
+        return utf8_decode($value);
+    }
+
+    return $converted;
+}
+
+function formatGermanDate(?string $date): string
+{
+    if ($date === null || $date === '') {
+        return '';
+    }
+    $date = substr($date, 0, 10);
+    $dt = DateTimeImmutable::createFromFormat('Y-m-d', $date);
+    return $dt ? $dt->format('d.m.Y') : $date;
+}
+
+function decodeImagePayload(string $payload): array
+{
+    $data = $payload;
+    $mime = 'image/png';
+    if (str_contains($payload, ',')) {
+        [$meta, $encoded] = explode(',', $payload, 2);
+        $data = $encoded;
+        if (preg_match('/data:(.*?);base64/', $meta, $matches)) {
+            $mime = strtolower(trim($matches[1]));
+        }
+    }
+
+    $binary = base64_decode($data, true);
+    if ($binary === false) {
+        throw new InvalidArgumentException('Bilddaten konnten nicht dekodiert werden.');
+    }
+
+    $allowed = [
+        'image/png' => 'png',
+        'image/jpeg' => 'jpg',
+        'image/jpg' => 'jpg',
+    ];
+    if (!isset($allowed[$mime])) {
+        throw new InvalidArgumentException('Nur PNG- oder JPEG-Dateien werden unterstützt.');
+    }
+
+    return [
+        'binary' => $binary,
+        'mime' => $mime,
+        'extension' => $allowed[$mime],
+    ];
+}
+
+function storagePath(string $relative = ''): string
+{
+    $base = realpath(__DIR__ . '/..');
+    if ($base === false) {
+        $base = __DIR__ . '/..';
+    }
+    $base = rtrim($base, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'storage';
+    if ($relative === '') {
+        return $base;
+    }
+
+    return $base . DIRECTORY_SEPARATOR . ltrim($relative, DIRECTORY_SEPARATOR);
+}
+
+function ensureStorageDirectory(string $relative): string
+{
+    $path = storagePath($relative);
+    if (!is_dir($path)) {
+        if (!mkdir($path, 0775, true) && !is_dir($path)) {
+            throw new RuntimeException('Verzeichnis konnte nicht erstellt werden: ' . $path);
+        }
+    }
+
+    return $path;
+}
+
+function getSetting(string $key): ?string
+{
+    $pdo = db();
+    $stmt = $pdo->prepare('SELECT `value` FROM settings WHERE `key` = :key');
+    $stmt->execute(['key' => $key]);
+    $value = $stmt->fetchColumn();
+    return $value === false ? null : $value;
+}
+
+function setSetting(string $key, ?string $value): void
+{
+    $pdo = db();
+    if ($value === null) {
+        $stmt = $pdo->prepare('DELETE FROM settings WHERE `key` = :key');
+        $stmt->execute(['key' => $key]);
+        return;
+    }
+
+    $stmt = $pdo->prepare('INSERT INTO settings (`key`, `value`, created_at, updated_at) VALUES (:key, :value, :created_at, :updated_at) ON DUPLICATE KEY UPDATE `value` = VALUES(`value`), updated_at = VALUES(updated_at)');
+    $timestamp = now();
+    $stmt->execute([
+        'key' => $key,
+        'value' => $value,
+        'created_at' => $timestamp,
+        'updated_at' => $timestamp,
+    ]);
+}
+
+function getInvoiceLogoDescriptor(): ?array
+{
+    $relative = getSetting('invoice_logo_path');
+    if (!$relative) {
+        return null;
+    }
+    $path = storagePath($relative);
+    if (!is_file($path)) {
+        return null;
+    }
+    $mime = getSetting('invoice_logo_mime') ?? (mime_content_type($path) ?: 'image/png');
+    $updatedAt = getSetting('invoice_logo_updated_at');
+
+    return [
+        'path' => $path,
+        'mime' => $mime,
+        'updated_at' => $updatedAt,
+    ];
+}
+
+function saveInvoiceLogoImage(string $payload): array
+{
+    $decoded = decodeImagePayload($payload);
+    deleteInvoiceLogo();
+    $directory = ensureStorageDirectory('invoice');
+    $filename = 'logo.' . $decoded['extension'];
+    $path = $directory . DIRECTORY_SEPARATOR . $filename;
+    if (file_put_contents($path, $decoded['binary']) === false) {
+        throw new RuntimeException('Logo konnte nicht gespeichert werden.');
+    }
+    $timestamp = now();
+    setSetting('invoice_logo_path', 'invoice/' . $filename);
+    setSetting('invoice_logo_mime', $decoded['mime']);
+    setSetting('invoice_logo_updated_at', $timestamp);
+
+    return [
+        'path' => $path,
+        'mime' => $decoded['mime'],
+        'updated_at' => $timestamp,
+    ];
+}
+
+function deleteInvoiceLogo(): void
+{
+    $descriptor = getInvoiceLogoDescriptor();
+    if ($descriptor && is_file($descriptor['path'])) {
+        @unlink($descriptor['path']);
+    }
+    setSetting('invoice_logo_path', null);
+    setSetting('invoice_logo_mime', null);
+    setSetting('invoice_logo_updated_at', null);
+}

--- a/backend/bootstrap.php
+++ b/backend/bootstrap.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+if (!extension_loaded('pdo_mysql')) {
+    http_response_code(500);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => 'PDO MySQL extension is required.']);
+    exit;
+}
+
+/**
+ * Retrieve configuration values merged from env/.env/install config.
+ */
+function config(): array
+{
+    static $config;
+    if ($config !== null) {
+        return $config;
+    }
+
+    $config = [
+        'host' => getEnvValue('DB_HOST', '127.0.0.1'),
+        'port' => getEnvValue('DB_PORT', '3306'),
+        'database' => getEnvValue('DB_DATABASE'),
+        'username' => getEnvValue('DB_USERNAME'),
+        'password' => getEnvValue('DB_PASSWORD'),
+        'api_token' => getEnvValue('API_TOKEN'),
+    ];
+
+    $configPath = __DIR__ . '/../install.config.php';
+    if (file_exists($configPath)) {
+        /** @var array $fileConfig */
+        $fileConfig = require $configPath;
+        $config = array_merge($config, array_filter($fileConfig, static fn ($value) => $value !== null));
+    }
+
+    foreach (['host', 'port', 'database', 'username', 'password'] as $requiredKey) {
+        if (($config[$requiredKey] ?? null) === null || $config[$requiredKey] === '') {
+            throw new RuntimeException(sprintf('Missing configuration for %s', $requiredKey));
+        }
+    }
+
+    return $config;
+}
+
+function getEnvValue(string $key, ?string $default = null): ?string
+{
+    $value = getenv($key);
+    if ($value !== false) {
+        return $value;
+    }
+
+    static $cachedEnv;
+    if ($cachedEnv === null) {
+        $cachedEnv = loadDotEnv(__DIR__ . '/../.env');
+    }
+
+    return $cachedEnv[$key] ?? $default;
+}
+
+function loadDotEnv(string $path): array
+{
+    if (!is_readable($path)) {
+        return [];
+    }
+
+    $values = [];
+    $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    foreach ($lines as $line) {
+        $line = trim($line);
+        if ($line === '' || $line[0] === '#') {
+            continue;
+        }
+
+        [$name, $value] = array_map('trim', explode('=', $line, 2));
+        $values[$name] = trim($value, "'\"");
+    }
+
+    return $values;
+}
+
+function db(): PDO
+{
+    static $pdo;
+    if ($pdo instanceof PDO) {
+        return $pdo;
+    }
+
+    $cfg = config();
+    $dsn = sprintf('mysql:host=%s;port=%s;dbname=%s;charset=utf8mb4', $cfg['host'], $cfg['port'], $cfg['database']);
+    $pdo = new PDO($dsn, $cfg['username'], $cfg['password'], [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ]);
+
+    return $pdo;
+}
+
+function jsonResponse($payload, int $status = 200): void
+{
+    http_response_code($status);
+    header('Content-Type: application/json');
+    echo json_encode($payload, JSON_PRETTY_PRINT);
+    exit;
+}
+
+function parseJsonBody(): array
+{
+    $raw = file_get_contents('php://input');
+    if ($raw === false || $raw === '') {
+        return [];
+    }
+
+    $data = json_decode($raw, true);
+    if (!is_array($data)) {
+        jsonResponse(['error' => 'Invalid JSON body.'], 400);
+    }
+
+    return $data;
+}
+
+function requireApiKey(): void
+{
+    $config = config();
+    $expected = $config['api_token'] ?? null;
+    if ($expected === null || $expected === '') {
+        jsonResponse(['error' => 'API token is not configured. Set API_TOKEN in the environment or install.config.php.'], 500);
+    }
+
+    $provided = null;
+    $headerSource = function_exists('getallheaders') ? getallheaders() : [];
+    $headers = array_change_key_case($headerSource ?: []);
+    if (isset($headers['x-api-key'])) {
+        $provided = $headers['x-api-key'];
+    } elseif (isset($_GET['token'])) {
+        $provided = $_GET['token'];
+    }
+
+    if ($provided === null || !hash_equals($expected, (string) $provided)) {
+        jsonResponse(['error' => 'Unauthorized.'], 401);
+    }
+}
+
+function now(): string
+{
+    return (new DateTimeImmutable('now', new DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+}
+
+function validateDate(string $value): bool
+{
+    return (bool) DateTimeImmutable::createFromFormat('Y-m-d', $value);
+}
+
+function validateDateTime(string $value): bool
+{
+    return (bool) DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $value);
+}

--- a/backend/lib/fpdf.php
+++ b/backend/lib/fpdf.php
@@ -1,0 +1,1934 @@
+<?php
+/*******************************************************************************
+* FPDF                                                                         *
+*                                                                              *
+* Version: 1.86                                                                *
+* Date:    2023-06-25                                                          *
+* Author:  Olivier PLATHEY                                                     *
+*******************************************************************************/
+
+class FPDF
+{
+const VERSION = '1.86';
+protected $page;               // current page number
+protected $n;                  // current object number
+protected $offsets;            // array of object offsets
+protected $buffer;             // buffer holding in-memory PDF
+protected $pages;              // array containing pages
+protected $state;              // current document state
+protected $compress;           // compression flag
+protected $iconv;              // whether iconv is available
+protected $k;                  // scale factor (number of points in user unit)
+protected $DefOrientation;     // default orientation
+protected $CurOrientation;     // current orientation
+protected $StdPageSizes;       // standard page sizes
+protected $DefPageSize;        // default page size
+protected $CurPageSize;        // current page size
+protected $CurRotation;        // current page rotation
+protected $PageInfo;           // page-related data
+protected $wPt, $hPt;          // dimensions of current page in points
+protected $w, $h;              // dimensions of current page in user unit
+protected $lMargin;            // left margin
+protected $tMargin;            // top margin
+protected $rMargin;            // right margin
+protected $bMargin;            // page break margin
+protected $cMargin;            // cell margin
+protected $x, $y;              // current position in user unit
+protected $lasth;              // height of last printed cell
+protected $LineWidth;          // line width in user unit
+protected $fontpath;           // directory containing fonts
+protected $CoreFonts;          // array of core font names
+protected $fonts;              // array of used fonts
+protected $FontFiles;          // array of font files
+protected $encodings;          // array of encodings
+protected $cmaps;              // array of ToUnicode CMaps
+protected $FontFamily;         // current font family
+protected $FontStyle;          // current font style
+protected $underline;          // underlining flag
+protected $CurrentFont;        // current font info
+protected $FontSizePt;         // current font size in points
+protected $FontSize;           // current font size in user unit
+protected $DrawColor;          // commands for drawing color
+protected $FillColor;          // commands for filling color
+protected $TextColor;          // commands for text color
+protected $ColorFlag;          // indicates whether fill and text colors are different
+protected $WithAlpha;          // indicates whether alpha channel is used
+protected $ws;                 // word spacing
+protected $images;             // array of used images
+protected $PageLinks;          // array of links in pages
+protected $links;              // array of internal links
+protected $AutoPageBreak;      // automatic page breaking
+protected $PageBreakTrigger;   // threshold used to trigger page breaks
+protected $InHeader;           // flag set when processing header
+protected $InFooter;           // flag set when processing footer
+protected $AliasNbPages;       // alias for total number of pages
+protected $ZoomMode;           // zoom display mode
+protected $LayoutMode;         // layout display mode
+protected $metadata;           // document properties
+protected $CreationDate;       // document creation date
+protected $PDFVersion;         // PDF version number
+
+/*******************************************************************************
+*                               Public methods                                 *
+*******************************************************************************/
+
+function __construct($orientation='P', $unit='mm', $size='A4')
+{
+	// Initialization of properties
+	$this->state = 0;
+	$this->page = 0;
+	$this->n = 2;
+	$this->buffer = '';
+	$this->pages = array();
+	$this->PageInfo = array();
+	$this->fonts = array();
+	$this->FontFiles = array();
+	$this->encodings = array();
+	$this->cmaps = array();
+	$this->images = array();
+	$this->links = array();
+	$this->InHeader = false;
+	$this->InFooter = false;
+	$this->lasth = 0;
+	$this->FontFamily = '';
+	$this->FontStyle = '';
+	$this->FontSizePt = 12;
+	$this->underline = false;
+	$this->DrawColor = '0 G';
+	$this->FillColor = '0 g';
+	$this->TextColor = '0 g';
+	$this->ColorFlag = false;
+	$this->WithAlpha = false;
+	$this->ws = 0;
+	$this->iconv = function_exists('iconv');
+	// Font path
+	if(defined('FPDF_FONTPATH'))
+		$this->fontpath = FPDF_FONTPATH;
+	else
+		$this->fontpath = dirname(__FILE__).'/font/';
+	// Core fonts
+	$this->CoreFonts = array('courier', 'helvetica', 'times', 'symbol', 'zapfdingbats');
+	// Scale factor
+	if($unit=='pt')
+		$this->k = 1;
+	elseif($unit=='mm')
+		$this->k = 72/25.4;
+	elseif($unit=='cm')
+		$this->k = 72/2.54;
+	elseif($unit=='in')
+		$this->k = 72;
+	else
+		$this->Error('Incorrect unit: '.$unit);
+	// Page sizes
+	$this->StdPageSizes = array('a3'=>array(841.89,1190.55), 'a4'=>array(595.28,841.89), 'a5'=>array(420.94,595.28),
+		'letter'=>array(612,792), 'legal'=>array(612,1008));
+	$size = $this->_getpagesize($size);
+	$this->DefPageSize = $size;
+	$this->CurPageSize = $size;
+	// Page orientation
+	$orientation = strtolower($orientation);
+	if($orientation=='p' || $orientation=='portrait')
+	{
+		$this->DefOrientation = 'P';
+		$this->w = $size[0];
+		$this->h = $size[1];
+	}
+	elseif($orientation=='l' || $orientation=='landscape')
+	{
+		$this->DefOrientation = 'L';
+		$this->w = $size[1];
+		$this->h = $size[0];
+	}
+	else
+		$this->Error('Incorrect orientation: '.$orientation);
+	$this->CurOrientation = $this->DefOrientation;
+	$this->wPt = $this->w*$this->k;
+	$this->hPt = $this->h*$this->k;
+	// Page rotation
+	$this->CurRotation = 0;
+	// Page margins (1 cm)
+	$margin = 28.35/$this->k;
+	$this->SetMargins($margin,$margin);
+	// Interior cell margin (1 mm)
+	$this->cMargin = $margin/10;
+	// Line width (0.2 mm)
+	$this->LineWidth = .567/$this->k;
+	// Automatic page break
+	$this->SetAutoPageBreak(true,2*$margin);
+	// Default display mode
+	$this->SetDisplayMode('default');
+	// Enable compression
+	$this->SetCompression(true);
+	// Metadata
+	$this->metadata = array('Producer'=>'FPDF '.self::VERSION);
+	// Set default PDF version number
+	$this->PDFVersion = '1.3';
+}
+
+function SetMargins($left, $top, $right=null)
+{
+	// Set left, top and right margins
+	$this->lMargin = $left;
+	$this->tMargin = $top;
+	if($right===null)
+		$right = $left;
+	$this->rMargin = $right;
+}
+
+function SetLeftMargin($margin)
+{
+	// Set left margin
+	$this->lMargin = $margin;
+	if($this->page>0 && $this->x<$margin)
+		$this->x = $margin;
+}
+
+function SetTopMargin($margin)
+{
+	// Set top margin
+	$this->tMargin = $margin;
+}
+
+function SetRightMargin($margin)
+{
+	// Set right margin
+	$this->rMargin = $margin;
+}
+
+function SetAutoPageBreak($auto, $margin=0)
+{
+	// Set auto page break mode and triggering margin
+	$this->AutoPageBreak = $auto;
+	$this->bMargin = $margin;
+	$this->PageBreakTrigger = $this->h-$margin;
+}
+
+function SetDisplayMode($zoom, $layout='default')
+{
+	// Set display mode in viewer
+	if($zoom=='fullpage' || $zoom=='fullwidth' || $zoom=='real' || $zoom=='default' || !is_string($zoom))
+		$this->ZoomMode = $zoom;
+	else
+		$this->Error('Incorrect zoom display mode: '.$zoom);
+	if($layout=='single' || $layout=='continuous' || $layout=='two' || $layout=='default')
+		$this->LayoutMode = $layout;
+	else
+		$this->Error('Incorrect layout display mode: '.$layout);
+}
+
+function SetCompression($compress)
+{
+	// Set page compression
+	if(function_exists('gzcompress'))
+		$this->compress = $compress;
+	else
+		$this->compress = false;
+}
+
+function SetTitle($title, $isUTF8=false)
+{
+	// Title of document
+	$this->metadata['Title'] = $isUTF8 ? $title : $this->_UTF8encode($title);
+}
+
+function SetAuthor($author, $isUTF8=false)
+{
+	// Author of document
+	$this->metadata['Author'] = $isUTF8 ? $author : $this->_UTF8encode($author);
+}
+
+function SetSubject($subject, $isUTF8=false)
+{
+	// Subject of document
+	$this->metadata['Subject'] = $isUTF8 ? $subject : $this->_UTF8encode($subject);
+}
+
+function SetKeywords($keywords, $isUTF8=false)
+{
+	// Keywords of document
+	$this->metadata['Keywords'] = $isUTF8 ? $keywords : $this->_UTF8encode($keywords);
+}
+
+function SetCreator($creator, $isUTF8=false)
+{
+	// Creator of document
+	$this->metadata['Creator'] = $isUTF8 ? $creator : $this->_UTF8encode($creator);
+}
+
+function AliasNbPages($alias='{nb}')
+{
+	// Define an alias for total number of pages
+	$this->AliasNbPages = $alias;
+}
+
+function Error($msg)
+{
+	// Fatal error
+	throw new Exception('FPDF error: '.$msg);
+}
+
+function Close()
+{
+	// Terminate document
+	if($this->state==3)
+		return;
+	if($this->page==0)
+		$this->AddPage();
+	// Page footer
+	$this->InFooter = true;
+	$this->Footer();
+	$this->InFooter = false;
+	// Close page
+	$this->_endpage();
+	// Close document
+	$this->_enddoc();
+}
+
+function AddPage($orientation='', $size='', $rotation=0)
+{
+	// Start a new page
+	if($this->state==3)
+		$this->Error('The document is closed');
+	$family = $this->FontFamily;
+	$style = $this->FontStyle.($this->underline ? 'U' : '');
+	$fontsize = $this->FontSizePt;
+	$lw = $this->LineWidth;
+	$dc = $this->DrawColor;
+	$fc = $this->FillColor;
+	$tc = $this->TextColor;
+	$cf = $this->ColorFlag;
+	if($this->page>0)
+	{
+		// Page footer
+		$this->InFooter = true;
+		$this->Footer();
+		$this->InFooter = false;
+		// Close page
+		$this->_endpage();
+	}
+	// Start new page
+	$this->_beginpage($orientation,$size,$rotation);
+	// Set line cap style to square
+	$this->_out('2 J');
+	// Set line width
+	$this->LineWidth = $lw;
+	$this->_out(sprintf('%.2F w',$lw*$this->k));
+	// Set font
+	if($family)
+		$this->SetFont($family,$style,$fontsize);
+	// Set colors
+	$this->DrawColor = $dc;
+	if($dc!='0 G')
+		$this->_out($dc);
+	$this->FillColor = $fc;
+	if($fc!='0 g')
+		$this->_out($fc);
+	$this->TextColor = $tc;
+	$this->ColorFlag = $cf;
+	// Page header
+	$this->InHeader = true;
+	$this->Header();
+	$this->InHeader = false;
+	// Restore line width
+	if($this->LineWidth!=$lw)
+	{
+		$this->LineWidth = $lw;
+		$this->_out(sprintf('%.2F w',$lw*$this->k));
+	}
+	// Restore font
+	if($family)
+		$this->SetFont($family,$style,$fontsize);
+	// Restore colors
+	if($this->DrawColor!=$dc)
+	{
+		$this->DrawColor = $dc;
+		$this->_out($dc);
+	}
+	if($this->FillColor!=$fc)
+	{
+		$this->FillColor = $fc;
+		$this->_out($fc);
+	}
+	$this->TextColor = $tc;
+	$this->ColorFlag = $cf;
+}
+
+function Header()
+{
+	// To be implemented in your own inherited class
+}
+
+function Footer()
+{
+	// To be implemented in your own inherited class
+}
+
+function PageNo()
+{
+	// Get current page number
+	return $this->page;
+}
+
+function SetDrawColor($r, $g=null, $b=null)
+{
+	// Set color for all stroking operations
+	if(($r==0 && $g==0 && $b==0) || $g===null)
+		$this->DrawColor = sprintf('%.3F G',$r/255);
+	else
+		$this->DrawColor = sprintf('%.3F %.3F %.3F RG',$r/255,$g/255,$b/255);
+	if($this->page>0)
+		$this->_out($this->DrawColor);
+}
+
+function SetFillColor($r, $g=null, $b=null)
+{
+	// Set color for all filling operations
+	if(($r==0 && $g==0 && $b==0) || $g===null)
+		$this->FillColor = sprintf('%.3F g',$r/255);
+	else
+		$this->FillColor = sprintf('%.3F %.3F %.3F rg',$r/255,$g/255,$b/255);
+	$this->ColorFlag = ($this->FillColor!=$this->TextColor);
+	if($this->page>0)
+		$this->_out($this->FillColor);
+}
+
+function SetTextColor($r, $g=null, $b=null)
+{
+	// Set color for text
+	if(($r==0 && $g==0 && $b==0) || $g===null)
+		$this->TextColor = sprintf('%.3F g',$r/255);
+	else
+		$this->TextColor = sprintf('%.3F %.3F %.3F rg',$r/255,$g/255,$b/255);
+	$this->ColorFlag = ($this->FillColor!=$this->TextColor);
+}
+
+function GetStringWidth($s)
+{
+	// Get width of a string in the current font
+	$cw = $this->CurrentFont['cw'];
+	$w = 0;
+	$s = (string)$s;
+	$l = strlen($s);
+	for($i=0;$i<$l;$i++)
+		$w += $cw[$s[$i]];
+	return $w*$this->FontSize/1000;
+}
+
+function SetLineWidth($width)
+{
+	// Set line width
+	$this->LineWidth = $width;
+	if($this->page>0)
+		$this->_out(sprintf('%.2F w',$width*$this->k));
+}
+
+function Line($x1, $y1, $x2, $y2)
+{
+	// Draw a line
+	$this->_out(sprintf('%.2F %.2F m %.2F %.2F l S',$x1*$this->k,($this->h-$y1)*$this->k,$x2*$this->k,($this->h-$y2)*$this->k));
+}
+
+function Rect($x, $y, $w, $h, $style='')
+{
+	// Draw a rectangle
+	if($style=='F')
+		$op = 'f';
+	elseif($style=='FD' || $style=='DF')
+		$op = 'B';
+	else
+		$op = 'S';
+	$this->_out(sprintf('%.2F %.2F %.2F %.2F re %s',$x*$this->k,($this->h-$y)*$this->k,$w*$this->k,-$h*$this->k,$op));
+}
+
+function AddFont($family, $style='', $file='', $dir='')
+{
+	// Add a TrueType, OpenType or Type1 font
+	$family = strtolower($family);
+	if($file=='')
+		$file = str_replace(' ','',$family).strtolower($style).'.php';
+	$style = strtoupper($style);
+	if($style=='IB')
+		$style = 'BI';
+	$fontkey = $family.$style;
+	if(isset($this->fonts[$fontkey]))
+		return;
+	if(strpos($file,'/')!==false || strpos($file,"\\")!==false)
+		$this->Error('Incorrect font definition file name: '.$file);
+	if($dir=='')
+		$dir = $this->fontpath;
+	if(substr($dir,-1)!='/' && substr($dir,-1)!='\\')
+		$dir .= '/';
+	$info = $this->_loadfont($dir.$file);
+	$info['i'] = count($this->fonts)+1;
+	if(!empty($info['file']))
+	{
+		// Embedded font
+		$info['file'] = $dir.$info['file'];
+		if($info['type']=='TrueType')
+			$this->FontFiles[$info['file']] = array('length1'=>$info['originalsize']);
+		else
+			$this->FontFiles[$info['file']] = array('length1'=>$info['size1'], 'length2'=>$info['size2']);
+	}
+	$this->fonts[$fontkey] = $info;
+}
+
+function SetFont($family, $style='', $size=0)
+{
+	// Select a font; size given in points
+	if($family=='')
+		$family = $this->FontFamily;
+	else
+		$family = strtolower($family);
+	$style = strtoupper($style);
+	if(strpos($style,'U')!==false)
+	{
+		$this->underline = true;
+		$style = str_replace('U','',$style);
+	}
+	else
+		$this->underline = false;
+	if($style=='IB')
+		$style = 'BI';
+	if($size==0)
+		$size = $this->FontSizePt;
+	// Test if font is already selected
+	if($this->FontFamily==$family && $this->FontStyle==$style && $this->FontSizePt==$size)
+		return;
+	// Test if font is already loaded
+	$fontkey = $family.$style;
+	if(!isset($this->fonts[$fontkey]))
+	{
+		// Test if one of the core fonts
+		if($family=='arial')
+			$family = 'helvetica';
+		if(in_array($family,$this->CoreFonts))
+		{
+			if($family=='symbol' || $family=='zapfdingbats')
+				$style = '';
+			$fontkey = $family.$style;
+			if(!isset($this->fonts[$fontkey]))
+				$this->AddFont($family,$style);
+		}
+		else
+			$this->Error('Undefined font: '.$family.' '.$style);
+	}
+	// Select it
+	$this->FontFamily = $family;
+	$this->FontStyle = $style;
+	$this->FontSizePt = $size;
+	$this->FontSize = $size/$this->k;
+	$this->CurrentFont = $this->fonts[$fontkey];
+	if($this->page>0)
+		$this->_out(sprintf('BT /F%d %.2F Tf ET',$this->CurrentFont['i'],$this->FontSizePt));
+}
+
+function SetFontSize($size)
+{
+	// Set font size in points
+	if($this->FontSizePt==$size)
+		return;
+	$this->FontSizePt = $size;
+	$this->FontSize = $size/$this->k;
+	if($this->page>0 && isset($this->CurrentFont))
+		$this->_out(sprintf('BT /F%d %.2F Tf ET',$this->CurrentFont['i'],$this->FontSizePt));
+}
+
+function AddLink()
+{
+	// Create a new internal link
+	$n = count($this->links)+1;
+	$this->links[$n] = array(0, 0);
+	return $n;
+}
+
+function SetLink($link, $y=0, $page=-1)
+{
+	// Set destination of internal link
+	if($y==-1)
+		$y = $this->y;
+	if($page==-1)
+		$page = $this->page;
+	$this->links[$link] = array($page, $y);
+}
+
+function Link($x, $y, $w, $h, $link)
+{
+	// Put a link on the page
+	$this->PageLinks[$this->page][] = array($x*$this->k, $this->hPt-$y*$this->k, $w*$this->k, $h*$this->k, $link);
+}
+
+function Text($x, $y, $txt)
+{
+	// Output a string
+	if(!isset($this->CurrentFont))
+		$this->Error('No font has been set');
+	$txt = (string)$txt;
+	$s = sprintf('BT %.2F %.2F Td (%s) Tj ET',$x*$this->k,($this->h-$y)*$this->k,$this->_escape($txt));
+	if($this->underline && $txt!=='')
+		$s .= ' '.$this->_dounderline($x,$y,$txt);
+	if($this->ColorFlag)
+		$s = 'q '.$this->TextColor.' '.$s.' Q';
+	$this->_out($s);
+}
+
+function AcceptPageBreak()
+{
+	// Accept automatic page break or not
+	return $this->AutoPageBreak;
+}
+
+function Cell($w, $h=0, $txt='', $border=0, $ln=0, $align='', $fill=false, $link='')
+{
+	// Output a cell
+	$k = $this->k;
+	if($this->y+$h>$this->PageBreakTrigger && !$this->InHeader && !$this->InFooter && $this->AcceptPageBreak())
+	{
+		// Automatic page break
+		$x = $this->x;
+		$ws = $this->ws;
+		if($ws>0)
+		{
+			$this->ws = 0;
+			$this->_out('0 Tw');
+		}
+		$this->AddPage($this->CurOrientation,$this->CurPageSize,$this->CurRotation);
+		$this->x = $x;
+		if($ws>0)
+		{
+			$this->ws = $ws;
+			$this->_out(sprintf('%.3F Tw',$ws*$k));
+		}
+	}
+	if($w==0)
+		$w = $this->w-$this->rMargin-$this->x;
+	$s = '';
+	if($fill || $border==1)
+	{
+		if($fill)
+			$op = ($border==1) ? 'B' : 'f';
+		else
+			$op = 'S';
+		$s = sprintf('%.2F %.2F %.2F %.2F re %s ',$this->x*$k,($this->h-$this->y)*$k,$w*$k,-$h*$k,$op);
+	}
+	if(is_string($border))
+	{
+		$x = $this->x;
+		$y = $this->y;
+		if(strpos($border,'L')!==false)
+			$s .= sprintf('%.2F %.2F m %.2F %.2F l S ',$x*$k,($this->h-$y)*$k,$x*$k,($this->h-($y+$h))*$k);
+		if(strpos($border,'T')!==false)
+			$s .= sprintf('%.2F %.2F m %.2F %.2F l S ',$x*$k,($this->h-$y)*$k,($x+$w)*$k,($this->h-$y)*$k);
+		if(strpos($border,'R')!==false)
+			$s .= sprintf('%.2F %.2F m %.2F %.2F l S ',($x+$w)*$k,($this->h-$y)*$k,($x+$w)*$k,($this->h-($y+$h))*$k);
+		if(strpos($border,'B')!==false)
+			$s .= sprintf('%.2F %.2F m %.2F %.2F l S ',$x*$k,($this->h-($y+$h))*$k,($x+$w)*$k,($this->h-($y+$h))*$k);
+	}
+	$txt = (string)$txt;
+	if($txt!=='')
+	{
+		if(!isset($this->CurrentFont))
+			$this->Error('No font has been set');
+		if($align=='R')
+			$dx = $w-$this->cMargin-$this->GetStringWidth($txt);
+		elseif($align=='C')
+			$dx = ($w-$this->GetStringWidth($txt))/2;
+		else
+			$dx = $this->cMargin;
+		if($this->ColorFlag)
+			$s .= 'q '.$this->TextColor.' ';
+		$s .= sprintf('BT %.2F %.2F Td (%s) Tj ET',($this->x+$dx)*$k,($this->h-($this->y+.5*$h+.3*$this->FontSize))*$k,$this->_escape($txt));
+		if($this->underline)
+			$s .= ' '.$this->_dounderline($this->x+$dx,$this->y+.5*$h+.3*$this->FontSize,$txt);
+		if($this->ColorFlag)
+			$s .= ' Q';
+		if($link)
+			$this->Link($this->x+$dx,$this->y+.5*$h-.5*$this->FontSize,$this->GetStringWidth($txt),$this->FontSize,$link);
+	}
+	if($s)
+		$this->_out($s);
+	$this->lasth = $h;
+	if($ln>0)
+	{
+		// Go to next line
+		$this->y += $h;
+		if($ln==1)
+			$this->x = $this->lMargin;
+	}
+	else
+		$this->x += $w;
+}
+
+function MultiCell($w, $h, $txt, $border=0, $align='J', $fill=false)
+{
+	// Output text with automatic or explicit line breaks
+	if(!isset($this->CurrentFont))
+		$this->Error('No font has been set');
+	$cw = $this->CurrentFont['cw'];
+	if($w==0)
+		$w = $this->w-$this->rMargin-$this->x;
+	$wmax = ($w-2*$this->cMargin)*1000/$this->FontSize;
+	$s = str_replace("\r",'',(string)$txt);
+	$nb = strlen($s);
+	if($nb>0 && $s[$nb-1]=="\n")
+		$nb--;
+	$b = 0;
+	if($border)
+	{
+		if($border==1)
+		{
+			$border = 'LTRB';
+			$b = 'LRT';
+			$b2 = 'LR';
+		}
+		else
+		{
+			$b2 = '';
+			if(strpos($border,'L')!==false)
+				$b2 .= 'L';
+			if(strpos($border,'R')!==false)
+				$b2 .= 'R';
+			$b = (strpos($border,'T')!==false) ? $b2.'T' : $b2;
+		}
+	}
+	$sep = -1;
+	$i = 0;
+	$j = 0;
+	$l = 0;
+	$ns = 0;
+	$nl = 1;
+	while($i<$nb)
+	{
+		// Get next character
+		$c = $s[$i];
+		if($c=="\n")
+		{
+			// Explicit line break
+			if($this->ws>0)
+			{
+				$this->ws = 0;
+				$this->_out('0 Tw');
+			}
+			$this->Cell($w,$h,substr($s,$j,$i-$j),$b,2,$align,$fill);
+			$i++;
+			$sep = -1;
+			$j = $i;
+			$l = 0;
+			$ns = 0;
+			$nl++;
+			if($border && $nl==2)
+				$b = $b2;
+			continue;
+		}
+		if($c==' ')
+		{
+			$sep = $i;
+			$ls = $l;
+			$ns++;
+		}
+		$l += $cw[$c];
+		if($l>$wmax)
+		{
+			// Automatic line break
+			if($sep==-1)
+			{
+				if($i==$j)
+					$i++;
+				if($this->ws>0)
+				{
+					$this->ws = 0;
+					$this->_out('0 Tw');
+				}
+				$this->Cell($w,$h,substr($s,$j,$i-$j),$b,2,$align,$fill);
+			}
+			else
+			{
+				if($align=='J')
+				{
+					$this->ws = ($ns>1) ? ($wmax-$ls)/1000*$this->FontSize/($ns-1) : 0;
+					$this->_out(sprintf('%.3F Tw',$this->ws*$this->k));
+				}
+				$this->Cell($w,$h,substr($s,$j,$sep-$j),$b,2,$align,$fill);
+				$i = $sep+1;
+			}
+			$sep = -1;
+			$j = $i;
+			$l = 0;
+			$ns = 0;
+			$nl++;
+			if($border && $nl==2)
+				$b = $b2;
+		}
+		else
+			$i++;
+	}
+	// Last chunk
+	if($this->ws>0)
+	{
+		$this->ws = 0;
+		$this->_out('0 Tw');
+	}
+	if($border && strpos($border,'B')!==false)
+		$b .= 'B';
+	$this->Cell($w,$h,substr($s,$j,$i-$j),$b,2,$align,$fill);
+	$this->x = $this->lMargin;
+}
+
+function Write($h, $txt, $link='')
+{
+	// Output text in flowing mode
+	if(!isset($this->CurrentFont))
+		$this->Error('No font has been set');
+	$cw = $this->CurrentFont['cw'];
+	$w = $this->w-$this->rMargin-$this->x;
+	$wmax = ($w-2*$this->cMargin)*1000/$this->FontSize;
+	$s = str_replace("\r",'',(string)$txt);
+	$nb = strlen($s);
+	$sep = -1;
+	$i = 0;
+	$j = 0;
+	$l = 0;
+	$nl = 1;
+	while($i<$nb)
+	{
+		// Get next character
+		$c = $s[$i];
+		if($c=="\n")
+		{
+			// Explicit line break
+			$this->Cell($w,$h,substr($s,$j,$i-$j),0,2,'',false,$link);
+			$i++;
+			$sep = -1;
+			$j = $i;
+			$l = 0;
+			if($nl==1)
+			{
+				$this->x = $this->lMargin;
+				$w = $this->w-$this->rMargin-$this->x;
+				$wmax = ($w-2*$this->cMargin)*1000/$this->FontSize;
+			}
+			$nl++;
+			continue;
+		}
+		if($c==' ')
+			$sep = $i;
+		$l += $cw[$c];
+		if($l>$wmax)
+		{
+			// Automatic line break
+			if($sep==-1)
+			{
+				if($this->x>$this->lMargin)
+				{
+					// Move to next line
+					$this->x = $this->lMargin;
+					$this->y += $h;
+					$w = $this->w-$this->rMargin-$this->x;
+					$wmax = ($w-2*$this->cMargin)*1000/$this->FontSize;
+					$i++;
+					$nl++;
+					continue;
+				}
+				if($i==$j)
+					$i++;
+				$this->Cell($w,$h,substr($s,$j,$i-$j),0,2,'',false,$link);
+			}
+			else
+			{
+				$this->Cell($w,$h,substr($s,$j,$sep-$j),0,2,'',false,$link);
+				$i = $sep+1;
+			}
+			$sep = -1;
+			$j = $i;
+			$l = 0;
+			if($nl==1)
+			{
+				$this->x = $this->lMargin;
+				$w = $this->w-$this->rMargin-$this->x;
+				$wmax = ($w-2*$this->cMargin)*1000/$this->FontSize;
+			}
+			$nl++;
+		}
+		else
+			$i++;
+	}
+	// Last chunk
+	if($i!=$j)
+		$this->Cell($l/1000*$this->FontSize,$h,substr($s,$j),0,0,'',false,$link);
+}
+
+function Ln($h=null)
+{
+	// Line feed; default value is the last cell height
+	$this->x = $this->lMargin;
+	if($h===null)
+		$this->y += $this->lasth;
+	else
+		$this->y += $h;
+}
+
+function Image($file, $x=null, $y=null, $w=0, $h=0, $type='', $link='')
+{
+	// Put an image on the page
+	if($file=='')
+		$this->Error('Image file name is empty');
+	if(!isset($this->images[$file]))
+	{
+		// First use of this image, get info
+		if($type=='')
+		{
+			$pos = strrpos($file,'.');
+			if(!$pos)
+				$this->Error('Image file has no extension and no type was specified: '.$file);
+			$type = substr($file,$pos+1);
+		}
+		$type = strtolower($type);
+		if($type=='jpeg')
+			$type = 'jpg';
+		$mtd = '_parse'.$type;
+		if(!method_exists($this,$mtd))
+			$this->Error('Unsupported image type: '.$type);
+		$info = $this->$mtd($file);
+		$info['i'] = count($this->images)+1;
+		$this->images[$file] = $info;
+	}
+	else
+		$info = $this->images[$file];
+
+	// Automatic width and height calculation if needed
+	if($w==0 && $h==0)
+	{
+		// Put image at 96 dpi
+		$w = -96;
+		$h = -96;
+	}
+	if($w<0)
+		$w = -$info['w']*72/$w/$this->k;
+	if($h<0)
+		$h = -$info['h']*72/$h/$this->k;
+	if($w==0)
+		$w = $h*$info['w']/$info['h'];
+	if($h==0)
+		$h = $w*$info['h']/$info['w'];
+
+	// Flowing mode
+	if($y===null)
+	{
+		if($this->y+$h>$this->PageBreakTrigger && !$this->InHeader && !$this->InFooter && $this->AcceptPageBreak())
+		{
+			// Automatic page break
+			$x2 = $this->x;
+			$this->AddPage($this->CurOrientation,$this->CurPageSize,$this->CurRotation);
+			$this->x = $x2;
+		}
+		$y = $this->y;
+		$this->y += $h;
+	}
+
+	if($x===null)
+		$x = $this->x;
+	$this->_out(sprintf('q %.2F 0 0 %.2F %.2F %.2F cm /I%d Do Q',$w*$this->k,$h*$this->k,$x*$this->k,($this->h-($y+$h))*$this->k,$info['i']));
+	if($link)
+		$this->Link($x,$y,$w,$h,$link);
+}
+
+function GetPageWidth()
+{
+	// Get current page width
+	return $this->w;
+}
+
+function GetPageHeight()
+{
+	// Get current page height
+	return $this->h;
+}
+
+function GetX()
+{
+	// Get x position
+	return $this->x;
+}
+
+function SetX($x)
+{
+	// Set x position
+	if($x>=0)
+		$this->x = $x;
+	else
+		$this->x = $this->w+$x;
+}
+
+function GetY()
+{
+	// Get y position
+	return $this->y;
+}
+
+function SetY($y, $resetX=true)
+{
+	// Set y position and optionally reset x
+	if($y>=0)
+		$this->y = $y;
+	else
+		$this->y = $this->h+$y;
+	if($resetX)
+		$this->x = $this->lMargin;
+}
+
+function SetXY($x, $y)
+{
+	// Set x and y positions
+	$this->SetX($x);
+	$this->SetY($y,false);
+}
+
+function Output($dest='', $name='', $isUTF8=false)
+{
+	// Output PDF to some destination
+	$this->Close();
+	if(strlen($name)==1 && strlen($dest)!=1)
+	{
+		// Fix parameter order
+		$tmp = $dest;
+		$dest = $name;
+		$name = $tmp;
+	}
+	if($dest=='')
+		$dest = 'I';
+	if($name=='')
+		$name = 'doc.pdf';
+	switch(strtoupper($dest))
+	{
+		case 'I':
+			// Send to standard output
+			$this->_checkoutput();
+			if(PHP_SAPI!='cli')
+			{
+				// We send to a browser
+				header('Content-Type: application/pdf');
+				header('Content-Disposition: inline; '.$this->_httpencode('filename',$name,$isUTF8));
+				header('Cache-Control: private, max-age=0, must-revalidate');
+				header('Pragma: public');
+			}
+			echo $this->buffer;
+			break;
+		case 'D':
+			// Download file
+			$this->_checkoutput();
+			header('Content-Type: application/pdf');
+			header('Content-Disposition: attachment; '.$this->_httpencode('filename',$name,$isUTF8));
+			header('Cache-Control: private, max-age=0, must-revalidate');
+			header('Pragma: public');
+			echo $this->buffer;
+			break;
+		case 'F':
+			// Save to local file
+			if(!file_put_contents($name,$this->buffer))
+				$this->Error('Unable to create output file: '.$name);
+			break;
+		case 'S':
+			// Return as a string
+			return $this->buffer;
+		default:
+			$this->Error('Incorrect output destination: '.$dest);
+	}
+	return '';
+}
+
+/*******************************************************************************
+*                              Protected methods                               *
+*******************************************************************************/
+
+protected function _checkoutput()
+{
+	if(PHP_SAPI!='cli')
+	{
+		if(headers_sent($file,$line))
+			$this->Error("Some data has already been output, can't send PDF file (output started at $file:$line)");
+	}
+	if(ob_get_length())
+	{
+		// The output buffer is not empty
+		if(preg_match('/^(\xEF\xBB\xBF)?\s*$/',ob_get_contents()))
+		{
+			// It contains only a UTF-8 BOM and/or whitespace, let's clean it
+			ob_clean();
+		}
+		else
+			$this->Error("Some data has already been output, can't send PDF file");
+	}
+}
+
+protected function _getpagesize($size)
+{
+	if(is_string($size))
+	{
+		$size = strtolower($size);
+		if(!isset($this->StdPageSizes[$size]))
+			$this->Error('Unknown page size: '.$size);
+		$a = $this->StdPageSizes[$size];
+		return array($a[0]/$this->k, $a[1]/$this->k);
+	}
+	else
+	{
+		if($size[0]>$size[1])
+			return array($size[1], $size[0]);
+		else
+			return $size;
+	}
+}
+
+protected function _beginpage($orientation, $size, $rotation)
+{
+	$this->page++;
+	$this->pages[$this->page] = '';
+	$this->PageLinks[$this->page] = array();
+	$this->state = 2;
+	$this->x = $this->lMargin;
+	$this->y = $this->tMargin;
+	$this->FontFamily = '';
+	// Check page size and orientation
+	if($orientation=='')
+		$orientation = $this->DefOrientation;
+	else
+		$orientation = strtoupper($orientation[0]);
+	if($size=='')
+		$size = $this->DefPageSize;
+	else
+		$size = $this->_getpagesize($size);
+	if($orientation!=$this->CurOrientation || $size[0]!=$this->CurPageSize[0] || $size[1]!=$this->CurPageSize[1])
+	{
+		// New size or orientation
+		if($orientation=='P')
+		{
+			$this->w = $size[0];
+			$this->h = $size[1];
+		}
+		else
+		{
+			$this->w = $size[1];
+			$this->h = $size[0];
+		}
+		$this->wPt = $this->w*$this->k;
+		$this->hPt = $this->h*$this->k;
+		$this->PageBreakTrigger = $this->h-$this->bMargin;
+		$this->CurOrientation = $orientation;
+		$this->CurPageSize = $size;
+	}
+	if($orientation!=$this->DefOrientation || $size[0]!=$this->DefPageSize[0] || $size[1]!=$this->DefPageSize[1])
+		$this->PageInfo[$this->page]['size'] = array($this->wPt, $this->hPt);
+	if($rotation!=0)
+	{
+		if($rotation%90!=0)
+			$this->Error('Incorrect rotation value: '.$rotation);
+		$this->PageInfo[$this->page]['rotation'] = $rotation;
+	}
+	$this->CurRotation = $rotation;
+}
+
+protected function _endpage()
+{
+	$this->state = 1;
+}
+
+protected function _loadfont($path)
+{
+	// Load a font definition file
+	include($path);
+	if(!isset($name))
+		$this->Error('Could not include font definition file: '.$path);
+	if(isset($enc))
+		$enc = strtolower($enc);
+	if(!isset($subsetted))
+		$subsetted = false;
+	return get_defined_vars();
+}
+
+protected function _isascii($s)
+{
+	// Test if string is ASCII
+	$nb = strlen($s);
+	for($i=0;$i<$nb;$i++)
+	{
+		if(ord($s[$i])>127)
+			return false;
+	}
+	return true;
+}
+
+protected function _httpencode($param, $value, $isUTF8)
+{
+	// Encode HTTP header field parameter
+	if($this->_isascii($value))
+		return $param.'="'.$value.'"';
+	if(!$isUTF8)
+		$value = $this->_UTF8encode($value);
+	return $param."*=UTF-8''".rawurlencode($value);
+}
+
+protected function _UTF8encode($s)
+{
+	// Convert ISO-8859-1 to UTF-8
+	if($this->iconv)
+		return iconv('ISO-8859-1','UTF-8',$s);
+	$res = '';
+	$nb = strlen($s);
+	for($i=0;$i<$nb;$i++)
+	{
+		$c = $s[$i];
+		$v = ord($c);
+		if($v>=128)
+		{
+			$res .= chr(0xC0 | ($v >> 6));
+			$res .= chr(0x80 | ($v & 0x3F));
+		}
+		else
+			$res .= $c;
+	}
+	return $res;
+}
+
+protected function _UTF8toUTF16($s)
+{
+	// Convert UTF-8 to UTF-16BE with BOM
+	$res = "\xFE\xFF";
+	if($this->iconv)
+		return $res.iconv('UTF-8','UTF-16BE',$s);
+	$nb = strlen($s);
+	$i = 0;
+	while($i<$nb)
+	{
+		$c1 = ord($s[$i++]);
+		if($c1>=224)
+		{
+			// 3-byte character
+			$c2 = ord($s[$i++]);
+			$c3 = ord($s[$i++]);
+			$res .= chr((($c1 & 0x0F)<<4) + (($c2 & 0x3C)>>2));
+			$res .= chr((($c2 & 0x03)<<6) + ($c3 & 0x3F));
+		}
+		elseif($c1>=192)
+		{
+			// 2-byte character
+			$c2 = ord($s[$i++]);
+			$res .= chr(($c1 & 0x1C)>>2);
+			$res .= chr((($c1 & 0x03)<<6) + ($c2 & 0x3F));
+		}
+		else
+		{
+			// Single-byte character
+			$res .= "\0".chr($c1);
+		}
+	}
+	return $res;
+}
+
+protected function _escape($s)
+{
+	// Escape special characters
+	if(strpos($s,'(')!==false || strpos($s,')')!==false || strpos($s,'\\')!==false || strpos($s,"\r")!==false)
+		return str_replace(array('\\','(',')',"\r"), array('\\\\','\\(','\\)','\\r'), $s);
+	else
+		return $s;
+}
+
+protected function _textstring($s)
+{
+	// Format a text string
+	if(!$this->_isascii($s))
+		$s = $this->_UTF8toUTF16($s);
+	return '('.$this->_escape($s).')';
+}
+
+protected function _dounderline($x, $y, $txt)
+{
+	// Underline text
+	$up = $this->CurrentFont['up'];
+	$ut = $this->CurrentFont['ut'];
+	$w = $this->GetStringWidth($txt)+$this->ws*substr_count($txt,' ');
+	return sprintf('%.2F %.2F %.2F %.2F re f',$x*$this->k,($this->h-($y-$up/1000*$this->FontSize))*$this->k,$w*$this->k,-$ut/1000*$this->FontSizePt);
+}
+
+protected function _parsejpg($file)
+{
+	// Extract info from a JPEG file
+	$a = getimagesize($file);
+	if(!$a)
+		$this->Error('Missing or incorrect image file: '.$file);
+	if($a[2]!=2)
+		$this->Error('Not a JPEG file: '.$file);
+	if(!isset($a['channels']) || $a['channels']==3)
+		$colspace = 'DeviceRGB';
+	elseif($a['channels']==4)
+		$colspace = 'DeviceCMYK';
+	else
+		$colspace = 'DeviceGray';
+	$bpc = isset($a['bits']) ? $a['bits'] : 8;
+	$data = file_get_contents($file);
+	return array('w'=>$a[0], 'h'=>$a[1], 'cs'=>$colspace, 'bpc'=>$bpc, 'f'=>'DCTDecode', 'data'=>$data);
+}
+
+protected function _parsepng($file)
+{
+	// Extract info from a PNG file
+	$f = fopen($file,'rb');
+	if(!$f)
+		$this->Error('Can\'t open image file: '.$file);
+	$info = $this->_parsepngstream($f,$file);
+	fclose($f);
+	return $info;
+}
+
+protected function _parsepngstream($f, $file)
+{
+	// Check signature
+	if($this->_readstream($f,8)!=chr(137).'PNG'.chr(13).chr(10).chr(26).chr(10))
+		$this->Error('Not a PNG file: '.$file);
+
+	// Read header chunk
+	$this->_readstream($f,4);
+	if($this->_readstream($f,4)!='IHDR')
+		$this->Error('Incorrect PNG file: '.$file);
+	$w = $this->_readint($f);
+	$h = $this->_readint($f);
+	$bpc = ord($this->_readstream($f,1));
+	if($bpc>8)
+		$this->Error('16-bit depth not supported: '.$file);
+	$ct = ord($this->_readstream($f,1));
+	if($ct==0 || $ct==4)
+		$colspace = 'DeviceGray';
+	elseif($ct==2 || $ct==6)
+		$colspace = 'DeviceRGB';
+	elseif($ct==3)
+		$colspace = 'Indexed';
+	else
+		$this->Error('Unknown color type: '.$file);
+	if(ord($this->_readstream($f,1))!=0)
+		$this->Error('Unknown compression method: '.$file);
+	if(ord($this->_readstream($f,1))!=0)
+		$this->Error('Unknown filter method: '.$file);
+	if(ord($this->_readstream($f,1))!=0)
+		$this->Error('Interlacing not supported: '.$file);
+	$this->_readstream($f,4);
+	$dp = '/Predictor 15 /Colors '.($colspace=='DeviceRGB' ? 3 : 1).' /BitsPerComponent '.$bpc.' /Columns '.$w;
+
+	// Scan chunks looking for palette, transparency and image data
+	$pal = '';
+	$trns = '';
+	$data = '';
+	do
+	{
+		$n = $this->_readint($f);
+		$type = $this->_readstream($f,4);
+		if($type=='PLTE')
+		{
+			// Read palette
+			$pal = $this->_readstream($f,$n);
+			$this->_readstream($f,4);
+		}
+		elseif($type=='tRNS')
+		{
+			// Read transparency info
+			$t = $this->_readstream($f,$n);
+			if($ct==0)
+				$trns = array(ord(substr($t,1,1)));
+			elseif($ct==2)
+				$trns = array(ord(substr($t,1,1)), ord(substr($t,3,1)), ord(substr($t,5,1)));
+			else
+			{
+				$pos = strpos($t,chr(0));
+				if($pos!==false)
+					$trns = array($pos);
+			}
+			$this->_readstream($f,4);
+		}
+		elseif($type=='IDAT')
+		{
+			// Read image data block
+			$data .= $this->_readstream($f,$n);
+			$this->_readstream($f,4);
+		}
+		elseif($type=='IEND')
+			break;
+		else
+			$this->_readstream($f,$n+4);
+	}
+	while($n);
+
+	if($colspace=='Indexed' && empty($pal))
+		$this->Error('Missing palette in '.$file);
+	$info = array('w'=>$w, 'h'=>$h, 'cs'=>$colspace, 'bpc'=>$bpc, 'f'=>'FlateDecode', 'dp'=>$dp, 'pal'=>$pal, 'trns'=>$trns);
+	if($ct>=4)
+	{
+		// Extract alpha channel
+		if(!function_exists('gzuncompress'))
+			$this->Error('Zlib not available, can\'t handle alpha channel: '.$file);
+		$data = gzuncompress($data);
+		$color = '';
+		$alpha = '';
+		if($ct==4)
+		{
+			// Gray image
+			$len = 2*$w;
+			for($i=0;$i<$h;$i++)
+			{
+				$pos = (1+$len)*$i;
+				$color .= $data[$pos];
+				$alpha .= $data[$pos];
+				$line = substr($data,$pos+1,$len);
+				$color .= preg_replace('/(.)./s','$1',$line);
+				$alpha .= preg_replace('/.(.)/s','$1',$line);
+			}
+		}
+		else
+		{
+			// RGB image
+			$len = 4*$w;
+			for($i=0;$i<$h;$i++)
+			{
+				$pos = (1+$len)*$i;
+				$color .= $data[$pos];
+				$alpha .= $data[$pos];
+				$line = substr($data,$pos+1,$len);
+				$color .= preg_replace('/(.{3})./s','$1',$line);
+				$alpha .= preg_replace('/.{3}(.)/s','$1',$line);
+			}
+		}
+		unset($data);
+		$data = gzcompress($color);
+		$info['smask'] = gzcompress($alpha);
+		$this->WithAlpha = true;
+		if($this->PDFVersion<'1.4')
+			$this->PDFVersion = '1.4';
+	}
+	$info['data'] = $data;
+	return $info;
+}
+
+protected function _readstream($f, $n)
+{
+	// Read n bytes from stream
+	$res = '';
+	while($n>0 && !feof($f))
+	{
+		$s = fread($f,$n);
+		if($s===false)
+			$this->Error('Error while reading stream');
+		$n -= strlen($s);
+		$res .= $s;
+	}
+	if($n>0)
+		$this->Error('Unexpected end of stream');
+	return $res;
+}
+
+protected function _readint($f)
+{
+	// Read a 4-byte integer from stream
+	$a = unpack('Ni',$this->_readstream($f,4));
+	return $a['i'];
+}
+
+protected function _parsegif($file)
+{
+	// Extract info from a GIF file (via PNG conversion)
+	if(!function_exists('imagepng'))
+		$this->Error('GD extension is required for GIF support');
+	if(!function_exists('imagecreatefromgif'))
+		$this->Error('GD has no GIF read support');
+	$im = imagecreatefromgif($file);
+	if(!$im)
+		$this->Error('Missing or incorrect image file: '.$file);
+	imageinterlace($im,0);
+	ob_start();
+	imagepng($im);
+	$data = ob_get_clean();
+	imagedestroy($im);
+	$f = fopen('php://temp','rb+');
+	if(!$f)
+		$this->Error('Unable to create memory stream');
+	fwrite($f,$data);
+	rewind($f);
+	$info = $this->_parsepngstream($f,$file);
+	fclose($f);
+	return $info;
+}
+
+protected function _out($s)
+{
+	// Add a line to the current page
+	if($this->state==2)
+		$this->pages[$this->page] .= $s."\n";
+	elseif($this->state==0)
+		$this->Error('No page has been added yet');
+	elseif($this->state==1)
+		$this->Error('Invalid call');
+	elseif($this->state==3)
+		$this->Error('The document is closed');
+}
+
+protected function _put($s)
+{
+	// Add a line to the document
+	$this->buffer .= $s."\n";
+}
+
+protected function _getoffset()
+{
+	return strlen($this->buffer);
+}
+
+protected function _newobj($n=null)
+{
+	// Begin a new object
+	if($n===null)
+		$n = ++$this->n;
+	$this->offsets[$n] = $this->_getoffset();
+	$this->_put($n.' 0 obj');
+}
+
+protected function _putstream($data)
+{
+	$this->_put('stream');
+	$this->_put($data);
+	$this->_put('endstream');
+}
+
+protected function _putstreamobject($data)
+{
+	if($this->compress)
+	{
+		$entries = '/Filter /FlateDecode ';
+		$data = gzcompress($data);
+	}
+	else
+		$entries = '';
+	$entries .= '/Length '.strlen($data);
+	$this->_newobj();
+	$this->_put('<<'.$entries.'>>');
+	$this->_putstream($data);
+	$this->_put('endobj');
+}
+
+protected function _putlinks($n)
+{
+	foreach($this->PageLinks[$n] as $pl)
+	{
+		$this->_newobj();
+		$rect = sprintf('%.2F %.2F %.2F %.2F',$pl[0],$pl[1],$pl[0]+$pl[2],$pl[1]-$pl[3]);
+		$s = '<</Type /Annot /Subtype /Link /Rect ['.$rect.'] /Border [0 0 0] ';
+		if(is_string($pl[4]))
+			$s .= '/A <</S /URI /URI '.$this->_textstring($pl[4]).'>>>>';
+		else
+		{
+			$l = $this->links[$pl[4]];
+			if(isset($this->PageInfo[$l[0]]['size']))
+				$h = $this->PageInfo[$l[0]]['size'][1];
+			else
+				$h = ($this->DefOrientation=='P') ? $this->DefPageSize[1]*$this->k : $this->DefPageSize[0]*$this->k;
+			$s .= sprintf('/Dest [%d 0 R /XYZ 0 %.2F null]>>',$this->PageInfo[$l[0]]['n'],$h-$l[1]*$this->k);
+		}
+		$this->_put($s);
+		$this->_put('endobj');
+	}
+}
+
+protected function _putpage($n)
+{
+	$this->_newobj();
+	$this->_put('<</Type /Page');
+	$this->_put('/Parent 1 0 R');
+	if(isset($this->PageInfo[$n]['size']))
+		$this->_put(sprintf('/MediaBox [0 0 %.2F %.2F]',$this->PageInfo[$n]['size'][0],$this->PageInfo[$n]['size'][1]));
+	if(isset($this->PageInfo[$n]['rotation']))
+		$this->_put('/Rotate '.$this->PageInfo[$n]['rotation']);
+	$this->_put('/Resources 2 0 R');
+	if(!empty($this->PageLinks[$n]))
+	{
+		$s = '/Annots [';
+		foreach($this->PageLinks[$n] as $pl)
+			$s .= $pl[5].' 0 R ';
+		$s .= ']';
+		$this->_put($s);
+	}
+	if($this->WithAlpha)
+		$this->_put('/Group <</Type /Group /S /Transparency /CS /DeviceRGB>>');
+	$this->_put('/Contents '.($this->n+1).' 0 R>>');
+	$this->_put('endobj');
+	// Page content
+	if(!empty($this->AliasNbPages))
+		$this->pages[$n] = str_replace($this->AliasNbPages,$this->page,$this->pages[$n]);
+	$this->_putstreamobject($this->pages[$n]);
+	// Link annotations
+	$this->_putlinks($n);
+}
+
+protected function _putpages()
+{
+	$nb = $this->page;
+	$n = $this->n;
+	for($i=1;$i<=$nb;$i++)
+	{
+		$this->PageInfo[$i]['n'] = ++$n;
+		$n++;
+		foreach($this->PageLinks[$i] as &$pl)
+			$pl[5] = ++$n;
+		unset($pl);
+	}
+	for($i=1;$i<=$nb;$i++)
+		$this->_putpage($i);
+	// Pages root
+	$this->_newobj(1);
+	$this->_put('<</Type /Pages');
+	$kids = '/Kids [';
+	for($i=1;$i<=$nb;$i++)
+		$kids .= $this->PageInfo[$i]['n'].' 0 R ';
+	$kids .= ']';
+	$this->_put($kids);
+	$this->_put('/Count '.$nb);
+	if($this->DefOrientation=='P')
+	{
+		$w = $this->DefPageSize[0];
+		$h = $this->DefPageSize[1];
+	}
+	else
+	{
+		$w = $this->DefPageSize[1];
+		$h = $this->DefPageSize[0];
+	}
+	$this->_put(sprintf('/MediaBox [0 0 %.2F %.2F]',$w*$this->k,$h*$this->k));
+	$this->_put('>>');
+	$this->_put('endobj');
+}
+
+protected function _putfonts()
+{
+	foreach($this->FontFiles as $file=>$info)
+	{
+		// Font file embedding
+		$this->_newobj();
+		$this->FontFiles[$file]['n'] = $this->n;
+		$font = file_get_contents($file);
+		if(!$font)
+			$this->Error('Font file not found: '.$file);
+		$compressed = (substr($file,-2)=='.z');
+		if(!$compressed && isset($info['length2']))
+			$font = substr($font,6,$info['length1']).substr($font,6+$info['length1']+6,$info['length2']);
+		$this->_put('<</Length '.strlen($font));
+		if($compressed)
+			$this->_put('/Filter /FlateDecode');
+		$this->_put('/Length1 '.$info['length1']);
+		if(isset($info['length2']))
+			$this->_put('/Length2 '.$info['length2'].' /Length3 0');
+		$this->_put('>>');
+		$this->_putstream($font);
+		$this->_put('endobj');
+	}
+	foreach($this->fonts as $k=>$font)
+	{
+		// Encoding
+		if(isset($font['diff']))
+		{
+			if(!isset($this->encodings[$font['enc']]))
+			{
+				$this->_newobj();
+				$this->_put('<</Type /Encoding /BaseEncoding /WinAnsiEncoding /Differences ['.$font['diff'].']>>');
+				$this->_put('endobj');
+				$this->encodings[$font['enc']] = $this->n;
+			}
+		}
+		// ToUnicode CMap
+		if(isset($font['uv']))
+		{
+			if(isset($font['enc']))
+				$cmapkey = $font['enc'];
+			else
+				$cmapkey = $font['name'];
+			if(!isset($this->cmaps[$cmapkey]))
+			{
+				$cmap = $this->_tounicodecmap($font['uv']);
+				$this->_putstreamobject($cmap);
+				$this->cmaps[$cmapkey] = $this->n;
+			}
+		}
+		// Font object
+		$this->fonts[$k]['n'] = $this->n+1;
+		$type = $font['type'];
+		$name = $font['name'];
+		if($font['subsetted'])
+			$name = 'AAAAAA+'.$name;
+		if($type=='Core')
+		{
+			// Core font
+			$this->_newobj();
+			$this->_put('<</Type /Font');
+			$this->_put('/BaseFont /'.$name);
+			$this->_put('/Subtype /Type1');
+			if($name!='Symbol' && $name!='ZapfDingbats')
+				$this->_put('/Encoding /WinAnsiEncoding');
+			if(isset($font['uv']))
+				$this->_put('/ToUnicode '.$this->cmaps[$cmapkey].' 0 R');
+			$this->_put('>>');
+			$this->_put('endobj');
+		}
+		elseif($type=='Type1' || $type=='TrueType')
+		{
+			// Additional Type1 or TrueType/OpenType font
+			$this->_newobj();
+			$this->_put('<</Type /Font');
+			$this->_put('/BaseFont /'.$name);
+			$this->_put('/Subtype /'.$type);
+			$this->_put('/FirstChar 32 /LastChar 255');
+			$this->_put('/Widths '.($this->n+1).' 0 R');
+			$this->_put('/FontDescriptor '.($this->n+2).' 0 R');
+			if(isset($font['diff']))
+				$this->_put('/Encoding '.$this->encodings[$font['enc']].' 0 R');
+			else
+				$this->_put('/Encoding /WinAnsiEncoding');
+			if(isset($font['uv']))
+				$this->_put('/ToUnicode '.$this->cmaps[$cmapkey].' 0 R');
+			$this->_put('>>');
+			$this->_put('endobj');
+			// Widths
+			$this->_newobj();
+			$cw = $font['cw'];
+			$s = '[';
+			for($i=32;$i<=255;$i++)
+				$s .= $cw[chr($i)].' ';
+			$this->_put($s.']');
+			$this->_put('endobj');
+			// Descriptor
+			$this->_newobj();
+			$s = '<</Type /FontDescriptor /FontName /'.$name;
+			foreach($font['desc'] as $k=>$v)
+				$s .= ' /'.$k.' '.$v;
+			if(!empty($font['file']))
+				$s .= ' /FontFile'.($type=='Type1' ? '' : '2').' '.$this->FontFiles[$font['file']]['n'].' 0 R';
+			$this->_put($s.'>>');
+			$this->_put('endobj');
+		}
+		else
+		{
+			// Allow for additional types
+			$mtd = '_put'.strtolower($type);
+			if(!method_exists($this,$mtd))
+				$this->Error('Unsupported font type: '.$type);
+			$this->$mtd($font);
+		}
+	}
+}
+
+protected function _tounicodecmap($uv)
+{
+	$ranges = '';
+	$nbr = 0;
+	$chars = '';
+	$nbc = 0;
+	foreach($uv as $c=>$v)
+	{
+		if(is_array($v))
+		{
+			$ranges .= sprintf("<%02X> <%02X> <%04X>\n",$c,$c+$v[1]-1,$v[0]);
+			$nbr++;
+		}
+		else
+		{
+			$chars .= sprintf("<%02X> <%04X>\n",$c,$v);
+			$nbc++;
+		}
+	}
+	$s = "/CIDInit /ProcSet findresource begin\n";
+	$s .= "12 dict begin\n";
+	$s .= "begincmap\n";
+	$s .= "/CIDSystemInfo\n";
+	$s .= "<</Registry (Adobe)\n";
+	$s .= "/Ordering (UCS)\n";
+	$s .= "/Supplement 0\n";
+	$s .= ">> def\n";
+	$s .= "/CMapName /Adobe-Identity-UCS def\n";
+	$s .= "/CMapType 2 def\n";
+	$s .= "1 begincodespacerange\n";
+	$s .= "<00> <FF>\n";
+	$s .= "endcodespacerange\n";
+	if($nbr>0)
+	{
+		$s .= "$nbr beginbfrange\n";
+		$s .= $ranges;
+		$s .= "endbfrange\n";
+	}
+	if($nbc>0)
+	{
+		$s .= "$nbc beginbfchar\n";
+		$s .= $chars;
+		$s .= "endbfchar\n";
+	}
+	$s .= "endcmap\n";
+	$s .= "CMapName currentdict /CMap defineresource pop\n";
+	$s .= "end\n";
+	$s .= "end";
+	return $s;
+}
+
+protected function _putimages()
+{
+	foreach(array_keys($this->images) as $file)
+	{
+		$this->_putimage($this->images[$file]);
+		unset($this->images[$file]['data']);
+		unset($this->images[$file]['smask']);
+	}
+}
+
+protected function _putimage(&$info)
+{
+	$this->_newobj();
+	$info['n'] = $this->n;
+	$this->_put('<</Type /XObject');
+	$this->_put('/Subtype /Image');
+	$this->_put('/Width '.$info['w']);
+	$this->_put('/Height '.$info['h']);
+	if($info['cs']=='Indexed')
+		$this->_put('/ColorSpace [/Indexed /DeviceRGB '.(strlen($info['pal'])/3-1).' '.($this->n+1).' 0 R]');
+	else
+	{
+		$this->_put('/ColorSpace /'.$info['cs']);
+		if($info['cs']=='DeviceCMYK')
+			$this->_put('/Decode [1 0 1 0 1 0 1 0]');
+	}
+	$this->_put('/BitsPerComponent '.$info['bpc']);
+	if(isset($info['f']))
+		$this->_put('/Filter /'.$info['f']);
+	if(isset($info['dp']))
+		$this->_put('/DecodeParms <<'.$info['dp'].'>>');
+	if(isset($info['trns']) && is_array($info['trns']))
+	{
+		$trns = '';
+		for($i=0;$i<count($info['trns']);$i++)
+			$trns .= $info['trns'][$i].' '.$info['trns'][$i].' ';
+		$this->_put('/Mask ['.$trns.']');
+	}
+	if(isset($info['smask']))
+		$this->_put('/SMask '.($this->n+1).' 0 R');
+	$this->_put('/Length '.strlen($info['data']).'>>');
+	$this->_putstream($info['data']);
+	$this->_put('endobj');
+	// Soft mask
+	if(isset($info['smask']))
+	{
+		$dp = '/Predictor 15 /Colors 1 /BitsPerComponent 8 /Columns '.$info['w'];
+		$smask = array('w'=>$info['w'], 'h'=>$info['h'], 'cs'=>'DeviceGray', 'bpc'=>8, 'f'=>$info['f'], 'dp'=>$dp, 'data'=>$info['smask']);
+		$this->_putimage($smask);
+	}
+	// Palette
+	if($info['cs']=='Indexed')
+		$this->_putstreamobject($info['pal']);
+}
+
+protected function _putxobjectdict()
+{
+	foreach($this->images as $image)
+		$this->_put('/I'.$image['i'].' '.$image['n'].' 0 R');
+}
+
+protected function _putresourcedict()
+{
+	$this->_put('/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]');
+	$this->_put('/Font <<');
+	foreach($this->fonts as $font)
+		$this->_put('/F'.$font['i'].' '.$font['n'].' 0 R');
+	$this->_put('>>');
+	$this->_put('/XObject <<');
+	$this->_putxobjectdict();
+	$this->_put('>>');
+}
+
+protected function _putresources()
+{
+	$this->_putfonts();
+	$this->_putimages();
+	// Resource dictionary
+	$this->_newobj(2);
+	$this->_put('<<');
+	$this->_putresourcedict();
+	$this->_put('>>');
+	$this->_put('endobj');
+}
+
+protected function _putinfo()
+{
+	$date = @date('YmdHisO',$this->CreationDate);
+	$this->metadata['CreationDate'] = 'D:'.substr($date,0,-2)."'".substr($date,-2)."'";
+	foreach($this->metadata as $key=>$value)
+		$this->_put('/'.$key.' '.$this->_textstring($value));
+}
+
+protected function _putcatalog()
+{
+	$n = $this->PageInfo[1]['n'];
+	$this->_put('/Type /Catalog');
+	$this->_put('/Pages 1 0 R');
+	if($this->ZoomMode=='fullpage')
+		$this->_put('/OpenAction ['.$n.' 0 R /Fit]');
+	elseif($this->ZoomMode=='fullwidth')
+		$this->_put('/OpenAction ['.$n.' 0 R /FitH null]');
+	elseif($this->ZoomMode=='real')
+		$this->_put('/OpenAction ['.$n.' 0 R /XYZ null null 1]');
+	elseif(!is_string($this->ZoomMode))
+		$this->_put('/OpenAction ['.$n.' 0 R /XYZ null null '.sprintf('%.2F',$this->ZoomMode/100).']');
+	if($this->LayoutMode=='single')
+		$this->_put('/PageLayout /SinglePage');
+	elseif($this->LayoutMode=='continuous')
+		$this->_put('/PageLayout /OneColumn');
+	elseif($this->LayoutMode=='two')
+		$this->_put('/PageLayout /TwoColumnLeft');
+}
+
+protected function _putheader()
+{
+	$this->_put('%PDF-'.$this->PDFVersion);
+}
+
+protected function _puttrailer()
+{
+	$this->_put('/Size '.($this->n+1));
+	$this->_put('/Root '.$this->n.' 0 R');
+	$this->_put('/Info '.($this->n-1).' 0 R');
+}
+
+protected function _enddoc()
+{
+	$this->CreationDate = time();
+	$this->_putheader();
+	$this->_putpages();
+	$this->_putresources();
+	// Info
+	$this->_newobj();
+	$this->_put('<<');
+	$this->_putinfo();
+	$this->_put('>>');
+	$this->_put('endobj');
+	// Catalog
+	$this->_newobj();
+	$this->_put('<<');
+	$this->_putcatalog();
+	$this->_put('>>');
+	$this->_put('endobj');
+	// Cross-ref
+	$offset = $this->_getoffset();
+	$this->_put('xref');
+	$this->_put('0 '.($this->n+1));
+	$this->_put('0000000000 65535 f ');
+	for($i=1;$i<=$this->n;$i++)
+		$this->_put(sprintf('%010d 00000 n ',$this->offsets[$i]));
+	// Trailer
+	$this->_put('trailer');
+	$this->_put('<<');
+	$this->_puttrailer();
+	$this->_put('>>');
+	$this->_put('startxref');
+	$this->_put($offset);
+	$this->_put('%%EOF');
+	$this->state = 3;
+}
+}
+?>

--- a/backend/update.php
+++ b/backend/update.php
@@ -1,0 +1,274 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Lightweight update endpoint to pull the latest changes for the current git branch.
+ *
+ * The script requires a secret token that must be provided either as the first CLI
+ * argument or as a `token` query parameter when called via HTTP. Set the secret
+ * using the `PMS_UPDATE_SECRET` environment variable.
+ */
+
+if (PHP_SAPI === 'cli') {
+    $providedToken = $argv[1] ?? null;
+} else {
+    header('Content-Type: application/json');
+    $providedToken = $_GET['token'] ?? null;
+}
+
+$expectedToken = getenv('PMS_UPDATE_SECRET');
+if ($expectedToken === false || $expectedToken === '') {
+    respond(false, 'Missing PMS_UPDATE_SECRET environment variable. Define it to enable updates.');
+}
+
+if ($providedToken === null || !hash_equals($expectedToken, $providedToken)) {
+    respond(false, 'Invalid or missing update token.', 401);
+}
+
+$repositoryPath = realpath(__DIR__ . '/..');
+if ($repositoryPath === false) {
+    respond(false, 'Unable to resolve repository path.');
+}
+
+$outputLog = [];
+
+$gitAvailable = is_dir($repositoryPath . '/.git')
+    && function_exists('proc_open')
+    && function_exists('proc_close');
+
+if ($gitAvailable) {
+    chdir($repositoryPath);
+
+    [$gitVersionExit, $gitVersionOutput] = runCommand('git --version');
+    $outputLog[] = ['Git availability', 'git --version', $gitVersionExit, $gitVersionOutput];
+
+    if ($gitVersionExit === 0) {
+        $commands = [
+            ['git status --short', 'Repository status'],
+            ['git rev-parse --abbrev-ref HEAD', 'Current branch'],
+        ];
+
+        $branch = null;
+
+        foreach ($commands as [$command, $label]) {
+            [$exitCode, $output] = runCommand($command);
+            $outputLog[] = [$label, $command, $exitCode, $output];
+            if ($exitCode !== 0) {
+                respond(false, sprintf('Command failed: %s', $command), 500, $outputLog);
+            }
+
+            if ($label === 'Current branch') {
+                $branch = trim($output);
+            }
+        }
+
+        if ($branch === null || $branch === '') {
+            respond(false, 'Could not determine the current branch.', 500, $outputLog);
+        }
+
+        $pullCommand = sprintf('git pull origin %s', escapeshellarg($branch));
+        [$pullExitCode, $pullOutput] = runCommand($pullCommand);
+        $outputLog[] = ['Pull latest changes', $pullCommand, $pullExitCode, $pullOutput];
+
+        if ($pullExitCode !== 0) {
+            respond(false, 'Update failed. Review the output for details.', 500, $outputLog);
+        }
+
+        respond(true, 'Repository updated successfully via git pull.', 200, $outputLog);
+    }
+
+    $gitAvailable = $gitVersionExit === 0;
+}
+
+$repoSlug = getenv('PMS_UPDATE_REPO_SLUG') ?: 'rinkelzz/realpms';
+$branch = getenv('PMS_UPDATE_BRANCH') ?: 'main';
+
+$outputLog[] = ['Git pull fallback', null, null, sprintf('Falling back to archive download (%s@%s)', $repoSlug, $branch)];
+$archiveUrl = getenv('PMS_UPDATE_ARCHIVE_URL') ?: sprintf(
+    'https://codeload.github.com/%s/zip/refs/heads/%s',
+    $repoSlug,
+    rawurlencode($branch)
+);
+
+if (!class_exists('ZipArchive')) {
+    respond(false, 'ZipArchive extension is required for archive updates.', 500, $outputLog);
+}
+
+$tempArchive = tempnam(sys_get_temp_dir(), 'realpms_update_');
+if ($tempArchive === false) {
+    respond(false, 'Could not create temporary file for archive download.', 500, $outputLog);
+}
+
+$downloadContext = stream_context_create([
+    'http' => ['timeout' => 60],
+    'https' => ['timeout' => 60],
+]);
+
+$archiveData = @file_get_contents($archiveUrl, false, $downloadContext);
+if ($archiveData === false) {
+    respond(false, sprintf('Failed to download archive from %s', $archiveUrl), 500, $outputLog);
+}
+
+if (file_put_contents($tempArchive, $archiveData) === false) {
+    respond(false, 'Failed to write archive to temporary location.', 500, $outputLog);
+}
+
+$zip = new ZipArchive();
+if ($zip->open($tempArchive) !== true) {
+    respond(false, 'Could not open downloaded archive.', 500, $outputLog);
+}
+
+$extractDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'realpms_extract_' . uniqid();
+if (!mkdir($extractDir, 0775) && !is_dir($extractDir)) {
+    $zip->close();
+    respond(false, 'Failed to create extraction directory.', 500, $outputLog);
+}
+
+$rootEntryName = $zip->getNameIndex(0);
+
+if ($zip->extractTo($extractDir) === false) {
+    $zip->close();
+    respond(false, 'Failed to extract archive contents.', 500, $outputLog);
+}
+
+$zip->close();
+$extractedRoot = $rootEntryName !== false
+    ? rtrim($extractDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . rtrim($rootEntryName, "\/")
+    : $extractDir;
+
+if (!is_dir($extractedRoot)) {
+    $extractedRoot = $extractDir;
+}
+
+try {
+    recursiveCopy($extractedRoot, $repositoryPath);
+} catch (RuntimeException $exception) {
+    @unlink($tempArchive);
+    deleteDirectory($extractDir);
+    respond(false, $exception->getMessage(), 500, $outputLog);
+}
+
+$outputLog[] = ['Archive update', $archiveUrl, 0, 'Files synchronized from downloaded archive'];
+
+@unlink($tempArchive);
+deleteDirectory($extractDir);
+
+respond(true, 'Repository updated successfully via archive download.', 200, $outputLog);
+
+function runCommand(string $command): array
+{
+    $descriptorSpec = [
+        1 => ['pipe', 'w'],
+        2 => ['pipe', 'w'],
+    ];
+
+    $process = proc_open($command, $descriptorSpec, $pipes);
+
+    if (!is_resource($process)) {
+        return [1, 'Could not execute command.'];
+    }
+
+    $stdout = stream_get_contents($pipes[1]);
+    $stderr = stream_get_contents($pipes[2]);
+
+    foreach ($pipes as $pipe) {
+        fclose($pipe);
+    }
+
+    $exitCode = proc_close($process);
+    $output = trim($stdout . ($stderr !== '' ? PHP_EOL . $stderr : ''));
+
+    return [$exitCode, $output];
+}
+
+function respond(bool $success, string $message, int $status = 200, array $log = []): void
+{
+    $payload = [
+        'success' => $success,
+        'message' => $message,
+        'log' => array_map(
+            static fn ($entry) => [
+                'label' => $entry[0] ?? null,
+                'command' => $entry[1] ?? null,
+                'exit_code' => $entry[2] ?? null,
+                'output' => $entry[3] ?? null,
+            ],
+            $log,
+        ),
+    ];
+
+    if (PHP_SAPI === 'cli') {
+        fwrite(STDOUT, json_encode($payload, JSON_PRETTY_PRINT) . PHP_EOL);
+        exit($success ? 0 : 1);
+    }
+
+    http_response_code($status);
+    header('Content-Type: application/json');
+    echo json_encode($payload, JSON_PRETTY_PRINT);
+    exit;
+}
+
+function recursiveCopy(string $source, string $destination): void
+{
+    if (is_dir($source)) {
+        if (!is_dir($destination) && !mkdir($destination, 0775, true) && !is_dir($destination)) {
+            throw new RuntimeException(sprintf('Failed to create directory: %s', $destination));
+        }
+
+        $items = scandir($source);
+        if ($items === false) {
+            throw new RuntimeException(sprintf('Failed to read directory: %s', $source));
+        }
+
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $srcPath = $source . DIRECTORY_SEPARATOR . $item;
+            $destPath = $destination . DIRECTORY_SEPARATOR . $item;
+
+            if (is_dir($srcPath)) {
+                recursiveCopy($srcPath, $destPath);
+            } else {
+                if (!copy($srcPath, $destPath)) {
+                    throw new RuntimeException(sprintf('Failed to copy %s to %s', $srcPath, $destPath));
+                }
+            }
+        }
+
+        return;
+    }
+
+    if (!copy($source, $destination)) {
+        throw new RuntimeException(sprintf('Failed to copy %s to %s', $source, $destination));
+    }
+}
+
+function deleteDirectory(string $path): void
+{
+    if (!is_dir($path)) {
+        return;
+    }
+
+    $items = scandir($path);
+    if ($items === false) {
+        return;
+    }
+
+    foreach ($items as $item) {
+        if ($item === '.' || $item === '..') {
+            continue;
+        }
+
+        $target = $path . DIRECTORY_SEPARATOR . $item;
+        if (is_dir($target)) {
+            deleteDirectory($target);
+        } else {
+            @unlink($target);
+        }
+    }
+
+    @rmdir($path);
+}

--- a/install.config.php.example
+++ b/install.config.php.example
@@ -1,0 +1,9 @@
+<?php
+return [
+    'host' => '127.0.0.1',
+    'port' => '3306',
+    'database' => 'realpms',
+    'username' => 'realpms_user',
+    'password' => 'secret',
+    'api_token' => 'change-me-api-token',
+];

--- a/install.php
+++ b/install.php
@@ -1,0 +1,632 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Hotel PMS install script.
+ *
+ * This script creates the initial MySQL tables required for the PMS prototype.
+ * It is intentionally framework-agnostic so it can be executed before Laravel
+ * is fully set up.
+ *
+ * Usage (CLI):
+ *   php install.php
+ *
+ * Usage (Browser):
+ *   Place this file on the server and open it. Ensure database credentials are
+ *   configured via environment variables first.
+ */
+
+if (!extension_loaded('pdo_mysql')) {
+    respond('PDO MySQL extension is required. Please enable it before running the installer.', true);
+}
+
+$config = loadConfiguration();
+
+try {
+    $pdo = new PDO(
+        sprintf('mysql:host=%s;port=%s;dbname=%s;charset=utf8mb4', $config['host'], $config['port'], $config['database']),
+        $config['username'],
+        $config['password'],
+        [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        ],
+    );
+} catch (PDOException $exception) {
+    respond('Connection failed: ' . $exception->getMessage(), true);
+}
+
+$statements = getSchemaStatements();
+$results = [];
+
+foreach ($statements as $table => $sql) {
+    try {
+        $pdo->exec($sql);
+        $results[] = sprintf('✓ Created/verified table `%s`', $table);
+    } catch (PDOException $exception) {
+        respond(sprintf('Error creating table %s: %s', $table, $exception->getMessage()), true, $results);
+    }
+}
+
+try {
+    if (!columnExists($pdo, 'guests', 'company_id')) {
+        $pdo->exec('ALTER TABLE guests ADD COLUMN company_id BIGINT UNSIGNED NULL AFTER country');
+        $results[] = '✓ Added column `company_id` to `guests`';
+    } else {
+        $results[] = '• Column `company_id` already present on `guests`';
+    }
+} catch (PDOException $exception) {
+    respond('Error ensuring company column on guests: ' . $exception->getMessage(), true, $results);
+}
+
+try {
+    if (!foreignKeyExists($pdo, 'guests', 'fk_guests_company')) {
+        $pdo->exec('ALTER TABLE guests ADD CONSTRAINT fk_guests_company FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE SET NULL');
+        $results[] = '✓ Added foreign key `fk_guests_company`';
+    } else {
+        $results[] = '• Foreign key `fk_guests_company` already present';
+    }
+} catch (PDOException $exception) {
+    respond('Error ensuring guest/company relation: ' . $exception->getMessage(), true, $results);
+}
+
+try {
+    $stmt = $pdo->query("SHOW COLUMNS FROM reservations LIKE 'status'");
+    $column = $stmt ? $stmt->fetch(PDO::FETCH_ASSOC) : false;
+    $type = $column['Type'] ?? '';
+    if (strpos($type, "'paid'") === false) {
+        $pdo->exec("ALTER TABLE reservations MODIFY status ENUM('tentative','confirmed','checked_in','paid','checked_out','cancelled','no_show') NOT NULL DEFAULT 'tentative'");
+        $results[] = '✓ Updated reservation status options';
+    } else {
+        $results[] = '• Reservation status options already current';
+    }
+} catch (PDOException $exception) {
+    respond('Error updating reservation status enum: ' . $exception->getMessage(), true, $results);
+}
+
+try {
+    $stmt = $pdo->query("SHOW COLUMNS FROM reservation_status_logs LIKE 'status'");
+    $column = $stmt ? $stmt->fetch(PDO::FETCH_ASSOC) : false;
+    $type = $column['Type'] ?? '';
+    if (strpos($type, "'paid'") === false) {
+        $pdo->exec("ALTER TABLE reservation_status_logs MODIFY status ENUM('tentative','confirmed','checked_in','paid','checked_out','cancelled','no_show') NOT NULL");
+        $results[] = '✓ Updated reservation status log options';
+    } else {
+        $results[] = '• Reservation status log options already current';
+    }
+} catch (PDOException $exception) {
+    respond('Error updating reservation status log enum: ' . $exception->getMessage(), true, $results);
+}
+
+try {
+    if (!columnExists($pdo, 'invoices', 'correction_number')) {
+        $pdo->exec("ALTER TABLE invoices ADD COLUMN correction_number VARCHAR(100) NULL UNIQUE AFTER invoice_number");
+        $results[] = '✓ Added column `correction_number` to `invoices`';
+    } else {
+        $results[] = '• Column `correction_number` already present on `invoices`';
+    }
+
+    if (!columnExists($pdo, 'invoices', 'type')) {
+        $pdo->exec("ALTER TABLE invoices ADD COLUMN type ENUM('invoice','correction') NOT NULL DEFAULT 'invoice' AFTER correction_number");
+        $results[] = '✓ Added column `type` to `invoices`';
+    } else {
+        $results[] = '• Column `type` already present on `invoices`';
+    }
+
+    if (!columnExists($pdo, 'invoices', 'parent_invoice_id')) {
+        $pdo->exec('ALTER TABLE invoices ADD COLUMN parent_invoice_id BIGINT UNSIGNED NULL AFTER type');
+        $results[] = '✓ Added column `parent_invoice_id` to `invoices`';
+    } else {
+        $results[] = '• Column `parent_invoice_id` already present on `invoices`';
+    }
+
+    if (!foreignKeyExists($pdo, 'invoices', 'fk_invoices_parent')) {
+        $pdo->exec('ALTER TABLE invoices ADD CONSTRAINT fk_invoices_parent FOREIGN KEY (parent_invoice_id) REFERENCES invoices(id) ON DELETE SET NULL');
+        $results[] = '✓ Added foreign key `fk_invoices_parent`';
+    } else {
+        $results[] = '• Foreign key `fk_invoices_parent` already present';
+    }
+} catch (PDOException $exception) {
+    respond('Error updating invoice metadata columns: ' . $exception->getMessage(), true, $results);
+}
+
+try {
+    $results[] = ensureSequenceSeed($pdo, 'sequence_reservation', 'reservations');
+    $results[] = ensureSequenceSeed($pdo, 'sequence_invoice', 'invoices');
+    $results[] = ensureSequenceSeed($pdo, 'sequence_invoice_correction', 'invoices');
+} catch (PDOException $exception) {
+    respond('Error initialising numbering sequences: ' . $exception->getMessage(), true, $results);
+}
+
+respond('Installation completed successfully.', false, $results);
+
+/**
+ * Load configuration from environment variables or an optional install config file.
+ */
+function loadConfiguration(): array
+{
+    $config = [
+        'host' => getEnvValue('DB_HOST', '127.0.0.1'),
+        'port' => getEnvValue('DB_PORT', '3306'),
+        'database' => getEnvValue('DB_DATABASE'),
+        'username' => getEnvValue('DB_USERNAME'),
+        'password' => getEnvValue('DB_PASSWORD'),
+    ];
+
+    $configPath = __DIR__ . '/install.config.php';
+    if (file_exists($configPath)) {
+        /** @var array $fileConfig */
+        $fileConfig = require $configPath;
+        $config = array_merge($config, array_filter($fileConfig, static fn ($value) => $value !== null));
+    }
+
+    $requiredKeys = ['host', 'port', 'database', 'username', 'password'];
+    foreach ($requiredKeys as $key) {
+        $value = $config[$key] ?? null;
+        if ($value === null || $value === '') {
+            respond(sprintf('Missing configuration value for %s. Set the corresponding environment variable or update install.config.php.', strtoupper($key)), true);
+        }
+    }
+
+    return $config;
+}
+
+/**
+ * Basic .env style lookup that prefers runtime environment variables.
+ */
+function getEnvValue(string $key, ?string $default = null): ?string
+{
+    if (getenv($key) !== false) {
+        return getenv($key);
+    }
+
+    static $cachedEnv;
+    if ($cachedEnv === null) {
+        $cachedEnv = loadDotEnv(__DIR__ . '/.env');
+    }
+
+    return $cachedEnv[$key] ?? $default;
+}
+
+function loadDotEnv(string $path): array
+{
+    if (!is_readable($path)) {
+        return [];
+    }
+
+    $values = [];
+    $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+
+    foreach ($lines as $line) {
+        $line = trim($line);
+        if ($line === '' || $line[0] === '#') {
+            continue;
+        }
+
+        [$name, $value] = array_map('trim', explode('=', $line, 2));
+        $values[$name] = trim($value, "'\"");
+    }
+
+    return $values;
+}
+
+function ensureSequenceSeed(PDO $pdo, string $key, string $table, string $column = 'id'): string
+{
+    $stmt = $pdo->prepare('SELECT `value` FROM settings WHERE `key` = :key');
+    $stmt->execute(['key' => $key]);
+    $existing = $stmt->fetchColumn();
+
+    $maxQuery = sprintf('SELECT MAX(`%s`) FROM `%s`', $column, $table);
+    $maxStmt = $pdo->query($maxQuery);
+    $maxValue = $maxStmt ? (int) $maxStmt->fetchColumn() : 0;
+
+    $timestamp = date('Y-m-d H:i:s');
+
+    if ($existing === false) {
+        $seed = $maxValue > 0 ? $maxValue : 0;
+        $insert = $pdo->prepare('INSERT INTO settings (`key`, `value`, created_at, updated_at) VALUES (:key, :value, :created_at, :updated_at)');
+        $insert->execute([
+            'key' => $key,
+            'value' => (string) $seed,
+            'created_at' => $timestamp,
+            'updated_at' => $timestamp,
+        ]);
+
+        return sprintf('✓ Initialised sequence `%s` at %d', $key, $seed);
+    }
+
+    $current = (int) $existing;
+    if ($maxValue > $current) {
+        $update = $pdo->prepare('UPDATE settings SET `value` = :value, updated_at = :updated_at WHERE `key` = :key');
+        $update->execute([
+            'value' => (string) $maxValue,
+            'updated_at' => $timestamp,
+            'key' => $key,
+        ]);
+
+        return sprintf('✓ Raised sequence `%s` to %d', $key, $maxValue);
+    }
+
+    return sprintf('• Sequence `%s` already initialised', $key);
+}
+
+function columnExists(PDO $pdo, string $table, string $column): bool
+{
+    $query = sprintf('SHOW COLUMNS FROM `%s` LIKE %s', $table, $pdo->quote($column));
+    $stmt = $pdo->query($query);
+    return $stmt !== false && $stmt->fetch() !== false;
+}
+
+function foreignKeyExists(PDO $pdo, string $table, string $constraintName): bool
+{
+    $sql = 'SELECT CONSTRAINT_NAME FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = :table AND CONSTRAINT_NAME = :constraint';
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute([
+        'table' => $table,
+        'constraint' => $constraintName,
+    ]);
+    return $stmt->fetchColumn() !== false;
+}
+
+function getSchemaStatements(): array
+{
+    return [
+        'roles' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS roles (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                name VARCHAR(100) NOT NULL UNIQUE,
+                description VARCHAR(255) NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'permissions' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS permissions (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                name VARCHAR(150) NOT NULL UNIQUE,
+                description VARCHAR(255) NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'users' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS users (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                name VARCHAR(150) NOT NULL,
+                email VARCHAR(150) NOT NULL UNIQUE,
+                password VARCHAR(255) NOT NULL,
+                remember_token VARCHAR(100) NULL,
+                last_login_at TIMESTAMP NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'role_user' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS role_user (
+                user_id BIGINT UNSIGNED NOT NULL,
+                role_id BIGINT UNSIGNED NOT NULL,
+                assigned_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (user_id, role_id),
+                CONSTRAINT fk_role_user_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+                CONSTRAINT fk_role_user_role FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'permission_role' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS permission_role (
+                permission_id BIGINT UNSIGNED NOT NULL,
+                role_id BIGINT UNSIGNED NOT NULL,
+                granted_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (permission_id, role_id),
+                CONSTRAINT fk_permission_role_permission FOREIGN KEY (permission_id) REFERENCES permissions(id) ON DELETE CASCADE,
+                CONSTRAINT fk_permission_role_role FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'settings' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS settings (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                `key` VARCHAR(150) NOT NULL UNIQUE,
+                `value` TEXT NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'companies' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS companies (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                name VARCHAR(150) NOT NULL,
+                email VARCHAR(150) NULL,
+                phone VARCHAR(50) NULL,
+                address VARCHAR(255) NULL,
+                city VARCHAR(100) NULL,
+                country VARCHAR(100) NULL,
+                notes TEXT NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'guests' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS guests (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                first_name VARCHAR(100) NOT NULL,
+                last_name VARCHAR(100) NOT NULL,
+                email VARCHAR(150) NULL,
+                phone VARCHAR(50) NULL,
+                address VARCHAR(255) NULL,
+                city VARCHAR(100) NULL,
+                country VARCHAR(100) NULL,
+                company_id BIGINT UNSIGNED NULL,
+                notes TEXT NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL,
+                CONSTRAINT fk_guests_company FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE SET NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'room_types' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS room_types (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                name VARCHAR(100) NOT NULL,
+                description TEXT NULL,
+                base_occupancy TINYINT UNSIGNED NOT NULL DEFAULT 1,
+                max_occupancy TINYINT UNSIGNED NOT NULL DEFAULT 1,
+                base_rate DECIMAL(10,2) NULL,
+                currency CHAR(3) NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'rooms' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS rooms (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                room_number VARCHAR(50) NOT NULL UNIQUE,
+                room_type_id BIGINT UNSIGNED NOT NULL,
+                floor VARCHAR(50) NULL,
+                status ENUM('available','occupied','out_of_order','in_cleaning') NOT NULL DEFAULT 'available',
+                notes TEXT NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL,
+                CONSTRAINT fk_rooms_room_type FOREIGN KEY (room_type_id) REFERENCES room_types(id)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'rate_plans' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS rate_plans (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                name VARCHAR(100) NOT NULL,
+                description TEXT NULL,
+                base_price DECIMAL(10,2) NOT NULL DEFAULT 0,
+                currency CHAR(3) NOT NULL DEFAULT 'EUR',
+                cancellation_policy TEXT NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'articles' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS articles (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                name VARCHAR(150) NOT NULL,
+                description TEXT NULL,
+                charge_scheme ENUM('per_person_per_day','per_room_per_day','per_stay','per_person','per_day') NOT NULL DEFAULT 'per_person_per_day',
+                unit_price DECIMAL(10,2) NOT NULL DEFAULT 0,
+                tax_rate DECIMAL(5,2) NOT NULL DEFAULT 19.00,
+                is_active TINYINT(1) NOT NULL DEFAULT 1,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'reservations' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS reservations (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                confirmation_number VARCHAR(100) NOT NULL UNIQUE,
+                guest_id BIGINT UNSIGNED NOT NULL,
+                status ENUM('tentative','confirmed','checked_in','paid','checked_out','cancelled','no_show') NOT NULL DEFAULT 'tentative',
+                check_in_date DATE NOT NULL,
+                check_out_date DATE NOT NULL,
+                adults SMALLINT UNSIGNED NOT NULL DEFAULT 1,
+                children SMALLINT UNSIGNED NOT NULL DEFAULT 0,
+                rate_plan_id BIGINT UNSIGNED NULL,
+                total_amount DECIMAL(10,2) NULL,
+                currency CHAR(3) NULL,
+                booked_via VARCHAR(100) NULL,
+                notes TEXT NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL,
+                CONSTRAINT fk_reservations_guest FOREIGN KEY (guest_id) REFERENCES guests(id),
+                CONSTRAINT fk_reservations_rate_plan FOREIGN KEY (rate_plan_id) REFERENCES rate_plans(id)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'reservation_rooms' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS reservation_rooms (
+                reservation_id BIGINT UNSIGNED NOT NULL,
+                room_id BIGINT UNSIGNED NOT NULL,
+                nightly_rate DECIMAL(10,2) NULL,
+                currency CHAR(3) NULL,
+                PRIMARY KEY (reservation_id, room_id),
+                CONSTRAINT fk_reservation_rooms_reservation FOREIGN KEY (reservation_id) REFERENCES reservations(id) ON DELETE CASCADE,
+                CONSTRAINT fk_reservation_rooms_room FOREIGN KEY (room_id) REFERENCES rooms(id)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'reservation_room_requests' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS reservation_room_requests (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                reservation_id BIGINT UNSIGNED NOT NULL,
+                room_type_id BIGINT UNSIGNED NOT NULL,
+                quantity SMALLINT UNSIGNED NOT NULL DEFAULT 1,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL,
+                CONSTRAINT fk_reservation_room_requests_reservation FOREIGN KEY (reservation_id) REFERENCES reservations(id) ON DELETE CASCADE,
+                CONSTRAINT fk_reservation_room_requests_type FOREIGN KEY (room_type_id) REFERENCES room_types(id)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'reservation_articles' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS reservation_articles (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                reservation_id BIGINT UNSIGNED NOT NULL,
+                article_id BIGINT UNSIGNED NOT NULL,
+                description VARCHAR(255) NOT NULL,
+                charge_scheme ENUM('per_person_per_day','per_room_per_day','per_stay','per_person','per_day') NOT NULL,
+                multiplier DECIMAL(10,2) NOT NULL DEFAULT 1,
+                quantity DECIMAL(10,2) NOT NULL DEFAULT 0,
+                unit_price DECIMAL(10,2) NOT NULL DEFAULT 0,
+                tax_rate DECIMAL(5,2) NOT NULL DEFAULT 19.00,
+                total_amount DECIMAL(10,2) NOT NULL DEFAULT 0,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL,
+                CONSTRAINT fk_reservation_articles_reservation FOREIGN KEY (reservation_id) REFERENCES reservations(id) ON DELETE CASCADE,
+                CONSTRAINT fk_reservation_articles_article FOREIGN KEY (article_id) REFERENCES articles(id)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'invoices' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS invoices (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                reservation_id BIGINT UNSIGNED NOT NULL,
+                invoice_number VARCHAR(100) NOT NULL UNIQUE,
+                issue_date DATE NOT NULL,
+                due_date DATE NULL,
+                total_amount DECIMAL(10,2) NOT NULL,
+                tax_amount DECIMAL(10,2) NULL,
+                status ENUM('draft','issued','paid','void') NOT NULL DEFAULT 'draft',
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL,
+                CONSTRAINT fk_invoices_reservation FOREIGN KEY (reservation_id) REFERENCES reservations(id)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'payments' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS payments (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                invoice_id BIGINT UNSIGNED NOT NULL,
+                method VARCHAR(50) NOT NULL,
+                amount DECIMAL(10,2) NOT NULL,
+                currency CHAR(3) NOT NULL DEFAULT 'EUR',
+                paid_at DATETIME NULL,
+                reference VARCHAR(150) NULL,
+                notes TEXT NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL,
+                CONSTRAINT fk_payments_invoice FOREIGN KEY (invoice_id) REFERENCES invoices(id) ON DELETE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'service_orders' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS service_orders (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                reservation_id BIGINT UNSIGNED NULL,
+                room_id BIGINT UNSIGNED NULL,
+                service_type VARCHAR(100) NOT NULL,
+                status ENUM('open','in_progress','completed','cancelled') NOT NULL DEFAULT 'open',
+                scheduled_at DATETIME NULL,
+                completed_at DATETIME NULL,
+                notes TEXT NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL,
+                CONSTRAINT fk_service_orders_reservation FOREIGN KEY (reservation_id) REFERENCES reservations(id) ON DELETE SET NULL,
+                CONSTRAINT fk_service_orders_room FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE SET NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'invoice_items' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS invoice_items (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                invoice_id BIGINT UNSIGNED NOT NULL,
+                description VARCHAR(255) NOT NULL,
+                quantity DECIMAL(10,2) NOT NULL DEFAULT 1,
+                unit_price DECIMAL(10,2) NOT NULL DEFAULT 0,
+                tax_rate DECIMAL(5,2) NULL,
+                total_amount DECIMAL(10,2) NOT NULL DEFAULT 0,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL,
+                CONSTRAINT fk_invoice_items_invoice FOREIGN KEY (invoice_id) REFERENCES invoices(id) ON DELETE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'reservation_documents' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS reservation_documents (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                reservation_id BIGINT UNSIGNED NOT NULL,
+                document_type VARCHAR(100) NOT NULL,
+                file_name VARCHAR(255) NULL,
+                file_path VARCHAR(255) NULL,
+                metadata JSON NULL,
+                uploaded_by BIGINT UNSIGNED NULL,
+                uploaded_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
+                CONSTRAINT fk_reservation_documents_reservation FOREIGN KEY (reservation_id) REFERENCES reservations(id) ON DELETE CASCADE,
+                CONSTRAINT fk_reservation_documents_user FOREIGN KEY (uploaded_by) REFERENCES users(id) ON DELETE SET NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'reservation_status_logs' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS reservation_status_logs (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                reservation_id BIGINT UNSIGNED NOT NULL,
+                status ENUM('tentative','confirmed','checked_in','paid','checked_out','cancelled','no_show') NOT NULL,
+                notes TEXT NULL,
+                recorded_by BIGINT UNSIGNED NULL,
+                recorded_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
+                CONSTRAINT fk_reservation_status_logs_reservation FOREIGN KEY (reservation_id) REFERENCES reservations(id) ON DELETE CASCADE,
+                CONSTRAINT fk_reservation_status_logs_user FOREIGN KEY (recorded_by) REFERENCES users(id) ON DELETE SET NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'housekeeping_logs' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS housekeeping_logs (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                room_id BIGINT UNSIGNED NOT NULL,
+                status ENUM('clean','dirty','in_progress','out_of_order','available','in_cleaning','occupied','maintenance') NOT NULL,
+                notes TEXT NULL,
+                recorded_by BIGINT UNSIGNED NULL,
+                recorded_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
+                CONSTRAINT fk_housekeeping_logs_room FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE,
+                CONSTRAINT fk_housekeeping_logs_user FOREIGN KEY (recorded_by) REFERENCES users(id) ON DELETE SET NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'tasks' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS tasks (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                room_id BIGINT UNSIGNED NULL,
+                assigned_to BIGINT UNSIGNED NULL,
+                title VARCHAR(150) NOT NULL,
+                description TEXT NULL,
+                status ENUM('open','in_progress','completed','cancelled') NOT NULL DEFAULT 'open',
+                due_date DATETIME NULL,
+                completed_at DATETIME NULL,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL,
+                CONSTRAINT fk_tasks_room FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE SET NULL,
+                CONSTRAINT fk_tasks_user FOREIGN KEY (assigned_to) REFERENCES users(id) ON DELETE SET NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+        'audit_logs' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS audit_logs (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                user_id BIGINT UNSIGNED NULL,
+                action VARCHAR(150) NOT NULL,
+                auditable_type VARCHAR(150) NOT NULL,
+                auditable_id BIGINT UNSIGNED NULL,
+                changes JSON NULL,
+                ip_address VARCHAR(45) NULL,
+                created_at TIMESTAMP NULL,
+                CONSTRAINT fk_audit_logs_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL,
+    ];
+}
+
+/**
+ * Output helper compatible with CLI or browser execution.
+ */
+function respond(string $message, bool $isError = false, array $log = []): void
+{
+    $status = $isError ? 'error' : 'success';
+    $payload = [
+        'status' => $status,
+        'message' => $message,
+        'steps' => $log,
+    ];
+
+    if (PHP_SAPI === 'cli') {
+        foreach ($log as $line) {
+            echo $line, PHP_EOL;
+        }
+        fwrite($isError ? STDERR : STDOUT, $message . PHP_EOL);
+        exit($isError ? 1 : 0);
+    }
+
+    header('Content-Type: application/json');
+    http_response_code($isError ? 500 : 200);
+    echo json_encode($payload, JSON_PRETTY_PRINT);
+    exit;
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,3345 @@
+const API_BASE = '../backend/api/index.php';
+const CALENDAR_STATUS_ORDER = ['tentative', 'confirmed', 'checked_in', 'paid', 'checked_out', 'cancelled', 'no_show'];
+const CALENDAR_COLOR_DEFAULTS = {
+    tentative: '#f97316',
+    confirmed: '#2563eb',
+    checked_in: '#16a34a',
+    paid: '#0ea5e9',
+    checked_out: '#6b7280',
+    cancelled: '#ef4444',
+    no_show: '#7c3aed',
+};
+
+const ARTICLE_SCHEME_LABELS = {
+    per_person_per_day: 'pro Person & Tag',
+    per_room_per_day: 'pro Zimmer & Tag',
+    per_stay: 'pro Aufenthalt',
+    per_person: 'pro Person',
+    per_day: 'pro Tag',
+};
+
+const RESERVATION_STATUS_ACTIONS = [
+    { status: 'checked_in', label: 'Check-in', title: 'Gast als angereist markieren' },
+    { status: 'paid', label: 'Bezahlt', title: 'Zahlung als erhalten markieren' },
+    { status: 'checked_out', label: 'Check-out', title: 'Gast als abgereist markieren' },
+    { status: 'no_show', label: 'No-Show', title: 'Gast als No-Show markieren' },
+];
+
+const state = {
+    token: null,
+    roomTypes: [],
+    ratePlans: [],
+    rooms: [],
+    reservations: [],
+    roles: [],
+    guests: [],
+    companies: [],
+    companiesLoaded: false,
+    articles: [],
+    articlesLoaded: false,
+    editingReservationId: null,
+    editingGuestId: null,
+    editingCompanyId: null,
+    editingArticleId: null,
+    loadedSections: new Set(),
+    calendarLabelMode: 'guest',
+    calendarColors: { ...CALENDAR_COLOR_DEFAULTS },
+    calendarColorTokens: {},
+    calendarColorsLoaded: false,
+    invoiceLogoDataUrl: null,
+    currentReservationInvoices: [],
+    guestLookupResults: [],
+    guestLookupTerm: '',
+    pendingRoomRequests: [],
+};
+
+const CALENDAR_DAYS = 14;
+const CALENDAR_LABEL_KEY = 'realpms_calendar_label_mode';
+
+try {
+    const storedMode = localStorage.getItem(CALENDAR_LABEL_KEY);
+    if (storedMode === 'company' || storedMode === 'guest') {
+        state.calendarLabelMode = storedMode;
+    }
+} catch (error) {
+    // ignore storage access issues
+}
+
+const notificationEl = document.getElementById('notification');
+const tokenInput = document.getElementById('api-token');
+const dashboardDateInput = document.getElementById('dashboard-date');
+const calendarLabelSelect = document.getElementById('calendar-label-mode');
+const calendarSettingsButton = document.getElementById('open-calendar-settings');
+const reportStartInput = document.getElementById('report-start');
+const reportEndInput = document.getElementById('report-end');
+const reservationForm = document.getElementById('reservation-form');
+const reservationDetails = reservationForm ? reservationForm.closest('details') : null;
+const reservationSummary = reservationDetails ? reservationDetails.querySelector('summary') : null;
+const reservationSubmitButton = reservationForm ? reservationForm.querySelector('button[type="submit"]') : null;
+const reservationCancelButton = document.getElementById('reservation-cancel-edit');
+const reservationMeta = document.getElementById('reservation-meta');
+const reservationNumberEl = document.getElementById('reservation-number');
+const reservationInvoiceStatus = document.getElementById('reservation-invoice-status');
+const reservationInvoiceLink = document.getElementById('reservation-invoice-link');
+const reservationCreateInvoiceButton = document.getElementById('reservation-create-invoice');
+const reservationPayInvoiceButton = document.getElementById('reservation-pay-invoice');
+const reservationsList = document.getElementById('reservations-list');
+const reservationCapacityEl = document.getElementById('reservation-capacity');
+const guestSearchInput = reservationForm ? reservationForm.querySelector('input[name="guest_search"]') : null;
+const guestIdInput = reservationForm ? reservationForm.querySelector('input[name="guest_id"]') : null;
+const guestSearchResults = document.getElementById('guest-search-results');
+const guestClearSelectionButton = document.getElementById('guest-clear-selection');
+const reservationGuestCompanySelect = reservationForm ? reservationForm.querySelector('select[name="guest_company"]') : null;
+const reservationArticleContainer = document.getElementById('reservation-article-options');
+const roomRequestList = document.getElementById('reservation-room-requests');
+const roomRequestTypeSelect = document.getElementById('reservation-room-request-type');
+const roomRequestQuantityInput = document.getElementById('reservation-room-request-quantity');
+const roomRequestAddButton = document.getElementById('reservation-room-request-add');
+const guestForm = document.getElementById('guest-form');
+const guestDetails = guestForm ? guestForm.closest('details') : null;
+const guestSummary = guestDetails ? guestDetails.querySelector('summary') : null;
+const guestSubmitButton = guestForm ? guestForm.querySelector('button[type="submit"]') : null;
+const guestCancelButton = document.getElementById('guest-cancel-edit');
+const guestCompanySelect = guestForm ? guestForm.querySelector('select[name="company_id"]') : null;
+const guestSummaryDefault = guestSummary ? guestSummary.textContent : 'Gast anlegen';
+const guestsList = document.getElementById('guests-list');
+const companiesList = document.getElementById('companies-list');
+const companyForm = document.getElementById('company-form');
+const companyDetails = companyForm ? companyForm.closest('details') : null;
+const companySummary = companyDetails ? companyDetails.querySelector('summary') : null;
+const companySubmitButton = companyForm ? companyForm.querySelector('button[type="submit"]') : null;
+const companyCancelButton = document.getElementById('company-cancel-edit');
+const companySummaryDefault = companySummary ? companySummary.textContent : 'Firma anlegen';
+const calendarColorForm = document.getElementById('calendar-color-form');
+const resetCalendarColorsButton = document.getElementById('reset-calendar-colors');
+const settingsReloadButton = document.getElementById('reload-settings');
+const occupancyCalendarContainer = document.getElementById('occupancy-calendar');
+const articlesList = document.getElementById('articles-list');
+const articleForm = document.getElementById('article-form');
+const articleSummary = articleForm ? articleForm.querySelector('h4') : null;
+const articleCancelButton = document.getElementById('article-cancel-edit');
+const reloadArticlesButton = document.getElementById('reload-articles');
+const invoiceLogoForm = document.getElementById('invoice-logo-form');
+const invoiceLogoInput = invoiceLogoForm ? invoiceLogoForm.querySelector('input[type="file"]') : null;
+const invoiceLogoPreview = document.getElementById('invoice-logo-preview');
+const removeInvoiceLogoButton = document.getElementById('remove-invoice-logo');
+
+let guestLookupDebounceId = null;
+let guestLookupRequestId = 0;
+
+const RESERVATION_STATUS_LABELS = {
+    tentative: 'Voranfrage',
+    confirmed: 'Bestätigt',
+    checked_in: 'Angereist',
+    paid: 'Bezahlt',
+    checked_out: 'Abgereist',
+    cancelled: 'Storniert',
+    no_show: 'Nicht erschienen',
+};
+
+const INVOICE_STATUS_LABELS = {
+    draft: 'Entwurf',
+    issued: 'Offen',
+    paid: 'Bezahlt',
+    void: 'Storniert',
+};
+
+function showMessage(message, type = 'info', timeout = 4000) {
+    if (!notificationEl) {
+        return;
+    }
+    notificationEl.textContent = message;
+    notificationEl.className = `notification show ${type}`;
+    if (timeout) {
+        setTimeout(() => {
+            notificationEl.className = 'notification';
+        }, timeout);
+    }
+}
+
+function requireToken() {
+    if (!state.token) {
+        showMessage('Bitte speichern Sie einen gültigen API-Token, um Daten laden zu können.', 'error');
+        return false;
+    }
+    return true;
+}
+
+function toLocalISODate(date = new Date()) {
+    if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+        return '';
+    }
+    const offset = date.getTimezoneOffset();
+    const local = new Date(date.getTime() - offset * 60000);
+    return local.toISOString().slice(0, 10);
+}
+
+function parseISODate(value) {
+    if (!value || typeof value !== 'string') {
+        return null;
+    }
+    const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (!match) {
+        return null;
+    }
+    const [, year, month, day] = match;
+    const date = new Date(Number(year), Number(month) - 1, Number(day));
+    return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function addDays(date, amount) {
+    const result = new Date(date);
+    result.setDate(result.getDate() + amount);
+    return result;
+}
+
+function dateKey(date) {
+    return toLocalISODate(date);
+}
+
+function isWeekend(date) {
+    const day = date.getDay();
+    return day === 0 || day === 6;
+}
+
+function normalizeStatusClass(value) {
+    if (!value) {
+        return '';
+    }
+    return value.toString().toLowerCase().replace(/[^a-z0-9_-]/g, '');
+}
+
+function formatReservationStatus(value) {
+    if (!value) {
+        return '';
+    }
+    const normalized = normalizeStatusClass(value);
+    return RESERVATION_STATUS_LABELS[normalized] || value;
+}
+
+function getReservationCalendarLabel(reservation, labelMode = 'guest') {
+    const guestName = `${reservation.first_name || ''} ${reservation.last_name || ''}`.trim();
+    const companyName = reservation.company_name || '';
+    if (labelMode === 'company') {
+        if (companyName) {
+            return companyName;
+        }
+        return guestName || reservation.confirmation_number || 'Belegt';
+    }
+    return guestName || companyName || reservation.confirmation_number || 'Belegt';
+}
+
+async function apiFetch(path, options = {}) {
+    const { skipAuth = false } = options;
+    const normalizedPath = path ? path.replace(/^\/+/, '') : '';
+    const url = normalizedPath ? `${API_BASE}/${normalizedPath}` : API_BASE;
+    const headers = new Headers(options.headers || {});
+    if (!skipAuth) {
+        if (!requireToken()) {
+            throw new Error('Kein API-Token gesetzt.');
+        }
+        headers.set('X-API-Key', state.token);
+    }
+    if (options.body && !headers.has('Content-Type')) {
+        headers.set('Content-Type', 'application/json');
+    }
+
+    const response = await fetch(url, { ...options, headers });
+    if (!response.ok) {
+        let message = `${response.status} ${response.statusText}`;
+        try {
+            const payload = await response.json();
+            if (payload && payload.error) {
+                message = payload.error;
+            }
+        } catch (error) {
+            // ignore json parse errors
+        }
+        throw new Error(message);
+    }
+
+    try {
+        return await response.json();
+    } catch (error) {
+        return null;
+    }
+}
+
+function setToken(token) {
+    state.token = token || null;
+    if (state.token) {
+        localStorage.setItem('realpms_api_token', state.token);
+        showMessage('API-Token gespeichert. Daten werden geladen...', 'success');
+        bootstrap();
+    } else {
+        localStorage.removeItem('realpms_api_token');
+        state.roomTypes = [];
+        state.ratePlans = [];
+        state.rooms = [];
+        state.reservations = [];
+        state.roles = [];
+        state.guests = [];
+        state.companies = [];
+        state.companiesLoaded = false;
+        state.editingReservationId = null;
+        state.editingGuestId = null;
+        state.editingCompanyId = null;
+        state.loadedSections.clear();
+        state.guestLookupResults = [];
+        state.guestLookupTerm = '';
+        populateCompanyDropdowns();
+        resetReservationForm();
+        resetGuestForm();
+        resetCompanyForm();
+        state.calendarColorsLoaded = false;
+        state.calendarColors = { ...CALENDAR_COLOR_DEFAULTS };
+        state.calendarColorTokens = {};
+        applyCalendarColors(state.calendarColors);
+        populateCalendarColorInputs();
+        showMessage('API-Token entfernt. Bitte neuen Token speichern.', 'info');
+    }
+}
+
+document.getElementById('token-form').addEventListener('submit', (event) => {
+    event.preventDefault();
+    const token = tokenInput.value.trim();
+    if (!token) {
+        showMessage('Token darf nicht leer sein.', 'error');
+        return;
+    }
+    setToken(token);
+});
+
+document.getElementById('clear-token').addEventListener('click', () => {
+    tokenInput.value = '';
+    setToken(null);
+});
+
+function setDefaultDates() {
+    const today = new Date();
+    const isoToday = toLocalISODate(today);
+    if (!dashboardDateInput.value) {
+        dashboardDateInput.value = isoToday;
+    }
+    const monthStart = toLocalISODate(new Date(today.getFullYear(), today.getMonth(), 1));
+    if (!reportStartInput.value) {
+        reportStartInput.value = monthStart;
+    }
+    if (!reportEndInput.value) {
+        reportEndInput.value = isoToday;
+    }
+}
+
+function showSection(sectionId) {
+    document.querySelectorAll('.main-nav button').forEach((button) => {
+        button.classList.toggle('active', button.dataset.section === sectionId);
+    });
+    document.querySelectorAll('section[data-section]').forEach((section) => {
+        section.classList.toggle('active', section.id === sectionId);
+    });
+    if (sectionLoaders[sectionId]) {
+        sectionLoaders[sectionId]();
+    }
+}
+
+document.querySelectorAll('.main-nav button').forEach((button) => {
+    button.addEventListener('click', () => showSection(button.dataset.section));
+});
+
+if (calendarSettingsButton) {
+    calendarSettingsButton.addEventListener('click', () => {
+        showSection('settings');
+        const settingsSection = document.getElementById('settings');
+        if (settingsSection && typeof settingsSection.scrollIntoView === 'function') {
+            settingsSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+    });
+}
+
+if (occupancyCalendarContainer) {
+    occupancyCalendarContainer.addEventListener('click', (event) => {
+        const target = event.target;
+        if (!(target instanceof Element)) {
+            return;
+        }
+        const entry = target.closest('.calendar-entry');
+        const cell = target.closest('td.occupied');
+        if (!cell) {
+            return;
+        }
+        const reservationIdAttr = entry?.dataset.reservationId || cell.dataset.reservationId;
+        const reservationId = Number(reservationIdAttr);
+        if (!reservationId) {
+            return;
+        }
+        showSection('reservations');
+        startReservationEdit(reservationId);
+    });
+}
+
+if (reservationCreateInvoiceButton) {
+    reservationCreateInvoiceButton.addEventListener('click', async () => {
+        if (!state.editingReservationId) {
+            showMessage('Bitte wählen Sie zuerst eine Reservierung aus.', 'error');
+            return;
+        }
+        if (!requireToken()) {
+            return;
+        }
+        reservationCreateInvoiceButton.disabled = true;
+        try {
+            const invoice = await apiFetch(`reservations/${state.editingReservationId}/invoice`, { method: 'POST' });
+            const number = invoice?.invoice_number || invoice?.id || '';
+            showMessage(number ? `Rechnung ${number} erstellt.` : 'Rechnung erstellt.', 'success');
+            await Promise.all([
+                loadReservations(true),
+                loadBilling(true),
+            ]);
+            await startReservationEdit(state.editingReservationId);
+        } catch (error) {
+            reservationCreateInvoiceButton.disabled = false;
+            showMessage(error.message, 'error');
+        }
+    });
+}
+
+if (reservationPayInvoiceButton) {
+    reservationPayInvoiceButton.addEventListener('click', async () => {
+        if (!state.editingReservationId) {
+            showMessage('Bitte wählen Sie zuerst eine Reservierung aus.', 'error');
+            return;
+        }
+        if (!requireToken()) {
+            return;
+        }
+        const latestInvoice = state.currentReservationInvoices[0];
+        if (!latestInvoice) {
+            showMessage('Für diese Reservierung existiert noch keine Rechnung.', 'error');
+            return;
+        }
+        if (latestInvoice.status === 'paid') {
+            showMessage('Die Rechnung ist bereits als bezahlt erfasst.', 'info');
+            return;
+        }
+        reservationPayInvoiceButton.disabled = true;
+        try {
+            await apiFetch(`reservations/${state.editingReservationId}/invoice-pay`, { method: 'POST' });
+            showMessage('Zahlung verbucht und Rechnung aktualisiert.', 'success');
+            await Promise.all([
+                loadReservations(true),
+                loadBilling(true),
+                loadDashboard(true),
+            ]);
+            await startReservationEdit(state.editingReservationId);
+        } catch (error) {
+            reservationPayInvoiceButton.disabled = false;
+            showMessage(error.message, 'error');
+        }
+    });
+}
+
+function formatDate(value) {
+    if (!value) {
+        return '';
+    }
+    if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
+        const parsed = parseISODate(value);
+        return parsed ? new Intl.DateTimeFormat('de-DE').format(parsed) : value;
+    }
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? value : date.toLocaleDateString('de-DE');
+}
+
+function formatDateTime(value) {
+    if (!value) {
+        return '';
+    }
+    if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}(?:[ T]\d{2}:\d{2}(?::\d{2})?)?$/.test(value)) {
+        const normalized = value.replace(' ', 'T');
+        const withSeconds = normalized.length === 16 ? `${normalized}:00` : normalized;
+        const date = new Date(withSeconds);
+        return Number.isNaN(date.getTime()) ? value : date.toLocaleString('de-DE');
+    }
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? value : date.toLocaleString('de-DE');
+}
+
+function formatCurrency(amount, currency = 'EUR') {
+    if (amount === null || amount === undefined || amount === '') {
+        return '';
+    }
+    const number = Number(amount);
+    if (Number.isNaN(number)) {
+        return amount;
+    }
+    return new Intl.NumberFormat('de-DE', { style: 'currency', currency }).format(number);
+}
+
+function escapeHtml(value) {
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}
+
+function formatChargeScheme(scheme) {
+    return ARTICLE_SCHEME_LABELS[scheme] || scheme;
+}
+
+function formatArticleHint(article) {
+    const scheme = formatChargeScheme(article.charge_scheme);
+    const price = formatCurrency(article.unit_price ?? 0, article.currency || 'EUR');
+    const tax = Number(article.tax_rate ?? 0).toFixed(1);
+    return `${scheme} · ${price} · MwSt ${tax}%`;
+}
+
+function updateReservationMeta(reservation = null) {
+    if (!reservationMeta) {
+        return;
+    }
+
+    if (!reservation) {
+        reservationMeta.classList.add('hidden');
+        state.currentReservationInvoices = [];
+        if (reservationNumberEl) {
+            reservationNumberEl.textContent = '--';
+        }
+        if (reservationInvoiceStatus) {
+            reservationInvoiceStatus.textContent = '';
+        }
+        if (reservationInvoiceLink) {
+            reservationInvoiceLink.href = '#';
+            reservationInvoiceLink.classList.add('hidden');
+        }
+        if (reservationCreateInvoiceButton) {
+            reservationCreateInvoiceButton.disabled = true;
+            reservationCreateInvoiceButton.textContent = 'Rechnung erstellen';
+        }
+        if (reservationPayInvoiceButton) {
+            reservationPayInvoiceButton.disabled = true;
+            reservationPayInvoiceButton.textContent = 'Als bezahlt verbuchen';
+        }
+        return;
+    }
+
+    reservationMeta.classList.remove('hidden');
+    state.currentReservationInvoices = Array.isArray(reservation.invoices) ? reservation.invoices : [];
+
+    if (reservationNumberEl) {
+        const confirmation = reservation.confirmation_number || `ID ${reservation.id}`;
+        reservationNumberEl.textContent = confirmation;
+    }
+
+    const latestInvoice = state.currentReservationInvoices[0] || null;
+    const reservationCurrency = reservation.currency || 'EUR';
+
+    if (reservationCreateInvoiceButton) {
+        reservationCreateInvoiceButton.disabled = false;
+        reservationCreateInvoiceButton.textContent = latestInvoice ? 'Neue Rechnung erstellen' : 'Rechnung erstellen';
+    }
+
+    if (latestInvoice && reservationInvoiceLink) {
+        reservationInvoiceLink.href = buildInvoicePdfUrl(latestInvoice.id);
+        reservationInvoiceLink.classList.remove('hidden');
+    } else if (reservationInvoiceLink) {
+        reservationInvoiceLink.href = '#';
+        reservationInvoiceLink.classList.add('hidden');
+    }
+
+    if (reservationInvoiceStatus) {
+        if (latestInvoice) {
+            const label = INVOICE_STATUS_LABELS[latestInvoice.status] || latestInvoice.status || 'Offen';
+            const amount = formatCurrency(latestInvoice.total_amount ?? 0, reservationCurrency);
+            const parts = [`Nr. ${latestInvoice.invoice_number || latestInvoice.id}`, label, amount];
+            if (latestInvoice.due_date) {
+                parts.push(`Fällig: ${formatDate(latestInvoice.due_date)}`);
+            }
+            reservationInvoiceStatus.textContent = parts.join(' · ');
+        } else {
+            reservationInvoiceStatus.textContent = 'Noch keine Rechnung erstellt.';
+        }
+    }
+
+    if (reservationPayInvoiceButton) {
+        if (latestInvoice && latestInvoice.status !== 'paid') {
+            reservationPayInvoiceButton.disabled = false;
+            reservationPayInvoiceButton.textContent = 'Als bezahlt verbuchen';
+        } else {
+            reservationPayInvoiceButton.disabled = true;
+            reservationPayInvoiceButton.textContent = latestInvoice ? 'Bereits bezahlt' : 'Als bezahlt verbuchen';
+        }
+    }
+}
+
+function buildInvoicePdfUrl(invoiceId) {
+    if (!invoiceId) {
+        return '#';
+    }
+    const tokenParam = state.token ? `?token=${encodeURIComponent(state.token)}` : '';
+    return `${API_BASE}/invoices/${invoiceId}/pdf${tokenParam}`;
+}
+
+function readFileAsDataUrl(file) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = () => reject(reader.error || new Error('Datei konnte nicht gelesen werden.'));
+        reader.readAsDataURL(file);
+    });
+}
+
+function updateInvoiceLogoPreview(dataUrl) {
+    if (!invoiceLogoPreview) {
+        return;
+    }
+    state.invoiceLogoDataUrl = dataUrl || null;
+    if (dataUrl) {
+        invoiceLogoPreview.innerHTML = `<img src="${dataUrl}" alt="Rechnungslogo" class="logo-image">`;
+        if (removeInvoiceLogoButton) {
+            removeInvoiceLogoButton.classList.remove('hidden');
+        }
+    } else {
+        invoiceLogoPreview.innerHTML = '<p class="muted">Noch kein Logo hochgeladen.</p>';
+        if (removeInvoiceLogoButton) {
+            removeInvoiceLogoButton.classList.add('hidden');
+        }
+    }
+}
+
+function normalizeHexColorInput(value) {
+    if (!value) {
+        return null;
+    }
+    const trimmed = value.toString().trim().replace(/^#/, '');
+    if (/^[0-9a-fA-F]{6}$/.test(trimmed)) {
+        return `#${trimmed.toLowerCase()}`;
+    }
+    if (/^[0-9a-fA-F]{3}$/.test(trimmed)) {
+        return `#${trimmed[0]}${trimmed[0]}${trimmed[1]}${trimmed[1]}${trimmed[2]}${trimmed[2]}`.toLowerCase();
+    }
+    return null;
+}
+
+function hexToRgb(color) {
+    const normalized = normalizeHexColorInput(color);
+    if (!normalized) {
+        return null;
+    }
+    const value = normalized.replace('#', '');
+    const bigint = parseInt(value, 16);
+    if (Number.isNaN(bigint)) {
+        return null;
+    }
+    return {
+        r: (bigint >> 16) & 255,
+        g: (bigint >> 8) & 255,
+        b: bigint & 255,
+    };
+}
+
+function rgbaFromHex(color, alpha = 0.55) {
+    const rgb = hexToRgb(color);
+    if (!rgb) {
+        return null;
+    }
+    const safeAlpha = Math.max(0, Math.min(1, alpha));
+    return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${safeAlpha})`;
+}
+
+function getReadableTextColor(color) {
+    const rgb = hexToRgb(color);
+    if (!rgb) {
+        return '#ffffff';
+    }
+    const luminance = (0.2126 * rgb.r + 0.7152 * rgb.g + 0.0722 * rgb.b) / 255;
+    return luminance > 0.6 ? '#111827' : '#ffffff';
+}
+
+function applyCalendarColors(colors = state.calendarColors) {
+    const merged = { ...CALENDAR_COLOR_DEFAULTS, ...(colors || {}) };
+    const tokens = {};
+    CALENDAR_STATUS_ORDER.forEach((status) => {
+        const fallback = CALENDAR_COLOR_DEFAULTS[status];
+        const normalized = normalizeHexColorInput(merged[status]) || fallback;
+        const border = rgbaFromHex(normalized, 0.55) || rgbaFromHex(fallback, 0.55) || 'rgba(37, 99, 235, 0.55)';
+        const textColor = getReadableTextColor(normalized);
+        document.documentElement.style.setProperty(`--calendar-color-${status}`, normalized);
+        document.documentElement.style.setProperty(`--calendar-border-${status}`, border);
+        document.documentElement.style.setProperty(`--calendar-text-${status}`, textColor);
+        tokens[status] = { color: normalized, border, text: textColor };
+    });
+    state.calendarColors = Object.fromEntries(
+        CALENDAR_STATUS_ORDER.map((status) => [status, tokens[status].color])
+    );
+    state.calendarColorTokens = tokens;
+}
+
+function populateCalendarColorInputs() {
+    if (!calendarColorForm) {
+        return;
+    }
+    CALENDAR_STATUS_ORDER.forEach((status) => {
+        const input = calendarColorForm.querySelector(`input[data-status="${status}"]`);
+        if (input) {
+            input.value = (state.calendarColors[status] || CALENDAR_COLOR_DEFAULTS[status]).toLowerCase();
+        }
+    });
+}
+
+function getCalendarColorToken(status) {
+    const normalized = normalizeStatusClass(status);
+    const token = state.calendarColorTokens[normalized];
+    if (token) {
+        return token;
+    }
+    const fallback = CALENDAR_COLOR_DEFAULTS[normalized] || CALENDAR_COLOR_DEFAULTS.confirmed;
+    const border = rgbaFromHex(fallback, 0.55) || 'rgba(37, 99, 235, 0.55)';
+    return {
+        color: fallback,
+        border,
+        text: getReadableTextColor(fallback),
+    };
+}
+
+function toSqlDateTime(value) {
+    if (!value) {
+        return null;
+    }
+    if (value.includes('T')) {
+        const [date, time] = value.split('T');
+        const normalizedTime = time.length === 5 ? `${time}:00` : time;
+        return `${date} ${normalizedTime}`;
+    }
+    return value;
+}
+
+function renderTable(containerId, columns, rows, emptyState = 'Keine Daten vorhanden') {
+    const container = document.getElementById(containerId);
+    if (!container) {
+        return;
+    }
+    container.innerHTML = '';
+    if (!rows || rows.length === 0) {
+        const empty = document.createElement('p');
+        empty.className = 'muted';
+        empty.textContent = emptyState;
+        container.appendChild(empty);
+        return;
+    }
+    const table = document.createElement('table');
+    table.className = 'data-table';
+    const thead = document.createElement('thead');
+    const headRow = document.createElement('tr');
+    columns.forEach((column) => {
+        const th = document.createElement('th');
+        th.textContent = column.label;
+        headRow.appendChild(th);
+    });
+    thead.appendChild(headRow);
+    table.appendChild(thead);
+    const tbody = document.createElement('tbody');
+    rows.forEach((row) => {
+        const tr = document.createElement('tr');
+        columns.forEach((column) => {
+            const td = document.createElement('td');
+            const value = column.render ? column.render(row) : row[column.key];
+            td.innerHTML = value === undefined || value === null ? '' : value;
+            tr.appendChild(td);
+        });
+        tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+    container.appendChild(table);
+}
+
+function getRoomTypeById(roomTypeId) {
+    return state.roomTypes.find((type) => Number(type.id) === Number(roomTypeId)) || null;
+}
+
+function normalizeClientRoomRequests(requests = []) {
+    const aggregated = new Map();
+    requests.forEach((request) => {
+        if (!request) {
+            return;
+        }
+        const typeId = Number(request.room_type_id ?? request.id ?? request.room_type);
+        if (!Number.isFinite(typeId) || typeId <= 0) {
+            return;
+        }
+        const quantityValue = Number(request.quantity ?? request.count ?? 1);
+        const quantity = Number.isFinite(quantityValue) && quantityValue > 0 ? Math.round(quantityValue) : 1;
+        const key = String(typeId);
+        const current = aggregated.get(key) || { room_type_id: typeId, quantity: 0 };
+        current.quantity += quantity;
+        aggregated.set(key, current);
+    });
+    return Array.from(aggregated.values());
+}
+
+function setReservationRoomRequests(requests) {
+    state.pendingRoomRequests = normalizeClientRoomRequests(Array.isArray(requests) ? requests : []);
+    renderReservationRoomRequests();
+    updateReservationCapacityHint();
+}
+
+function addReservationRoomRequest(typeId, quantity = 1) {
+    const normalizedId = Number(typeId);
+    if (!Number.isFinite(normalizedId) || normalizedId <= 0) {
+        return;
+    }
+    const normalizedQuantity = Number.isFinite(Number(quantity)) && Number(quantity) > 0 ? Math.round(Number(quantity)) : 1;
+    const existing = state.pendingRoomRequests.find((entry) => Number(entry.room_type_id) === normalizedId);
+    if (existing) {
+        existing.quantity += normalizedQuantity;
+    } else {
+        state.pendingRoomRequests.push({ room_type_id: normalizedId, quantity: normalizedQuantity });
+    }
+    renderReservationRoomRequests();
+    updateReservationCapacityHint();
+}
+
+function updateReservationRoomRequestQuantity(typeId, quantity) {
+    const normalizedId = Number(typeId);
+    if (!Number.isFinite(normalizedId) || normalizedId <= 0) {
+        return;
+    }
+    const normalizedQuantity = Number.isFinite(Number(quantity)) && Number(quantity) > 0 ? Math.round(Number(quantity)) : 1;
+    state.pendingRoomRequests = state.pendingRoomRequests.map((entry) => (
+        Number(entry.room_type_id) === normalizedId
+            ? { ...entry, quantity: normalizedQuantity }
+            : entry
+    ));
+    renderReservationRoomRequests();
+    updateReservationCapacityHint();
+}
+
+function removeReservationRoomRequest(typeId) {
+    const normalizedId = Number(typeId);
+    state.pendingRoomRequests = state.pendingRoomRequests.filter((entry) => Number(entry.room_type_id) !== normalizedId);
+    renderReservationRoomRequests();
+    updateReservationCapacityHint();
+}
+
+function calculateRoomRequestCapacityClient(requests = state.pendingRoomRequests) {
+    return requests.reduce((total, request) => {
+        const roomType = getRoomTypeById(request.room_type_id);
+        const capacity = Number(roomType?.max_occupancy ?? roomType?.base_occupancy ?? 0);
+        const quantity = Number(request.quantity ?? 0);
+        if (Number.isFinite(capacity) && capacity > 0 && Number.isFinite(quantity) && quantity > 0) {
+            return total + capacity * quantity;
+        }
+        return total;
+    }, 0);
+}
+
+function renderReservationRoomRequests() {
+    if (!roomRequestList) {
+        return;
+    }
+
+    roomRequestList.innerHTML = '';
+    if (!state.pendingRoomRequests.length) {
+        const empty = document.createElement('p');
+        empty.className = 'muted small-text';
+        empty.textContent = 'Keine Kategorie ausgewählt.';
+        roomRequestList.appendChild(empty);
+        return;
+    }
+
+    const sorted = [...state.pendingRoomRequests].sort((a, b) => {
+        const typeA = getRoomTypeById(a.room_type_id)?.name || '';
+        const typeB = getRoomTypeById(b.room_type_id)?.name || '';
+        return typeA.localeCompare(typeB, 'de', { sensitivity: 'base' });
+    });
+
+    const fragment = document.createDocumentFragment();
+    sorted.forEach((request) => {
+        const container = document.createElement('div');
+        container.className = 'room-request-row';
+        container.dataset.roomTypeId = String(request.room_type_id);
+
+        const info = document.createElement('div');
+        info.className = 'room-request-info';
+        const roomType = getRoomTypeById(request.room_type_id);
+        const name = roomType?.name || `Kategorie ${request.room_type_id}`;
+        const capacity = Number(roomType?.max_occupancy ?? roomType?.base_occupancy ?? 0);
+        const title = document.createElement('strong');
+        title.textContent = name;
+        info.appendChild(title);
+        if (capacity > 0) {
+            const meta = document.createElement('span');
+            meta.className = 'room-request-meta';
+            meta.textContent = `Kapazität: ${capacity} Gäste`;
+            info.appendChild(meta);
+        }
+        container.appendChild(info);
+
+        const controls = document.createElement('div');
+        controls.className = 'room-request-actions';
+
+        const quantityLabel = document.createElement('label');
+        quantityLabel.className = 'inline-label';
+        quantityLabel.textContent = 'Anzahl';
+        const quantityInput = document.createElement('input');
+        quantityInput.type = 'number';
+        quantityInput.min = '1';
+        quantityInput.value = String(request.quantity);
+        quantityInput.dataset.role = 'room-request-quantity';
+        quantityLabel.appendChild(quantityInput);
+        controls.appendChild(quantityLabel);
+
+        const removeButton = document.createElement('button');
+        removeButton.type = 'button';
+        removeButton.className = 'secondary small';
+        removeButton.dataset.action = 'remove-room-request';
+        removeButton.textContent = 'Entfernen';
+        controls.appendChild(removeButton);
+
+        container.appendChild(controls);
+        fragment.appendChild(container);
+    });
+
+    roomRequestList.appendChild(fragment);
+}
+
+function deriveRoomRequestsFromRooms(rooms) {
+    if (!Array.isArray(rooms) || rooms.length === 0) {
+        return [];
+    }
+    const aggregated = new Map();
+    rooms.forEach((room) => {
+        const typeId = Number(room.room_type_id ?? room.room_type ?? 0);
+        if (!Number.isFinite(typeId) || typeId <= 0) {
+            return;
+        }
+        const key = String(typeId);
+        const current = aggregated.get(key) || { room_type_id: typeId, quantity: 0 };
+        current.quantity += 1;
+        aggregated.set(key, current);
+    });
+    return Array.from(aggregated.values());
+}
+
+function updateReservationCapacityHint() {
+    if (!reservationForm || !reservationCapacityEl) {
+        return;
+    }
+    const adults = Number(reservationForm.adults?.value || 0);
+    const children = Number(reservationForm.children?.value || 0);
+    const guestTotal = adults + children;
+    const requests = state.pendingRoomRequests;
+
+    if (!requests.length) {
+        reservationCapacityEl.textContent = 'Bitte mindestens eine Zimmerkategorie hinzufügen.';
+        reservationCapacityEl.classList.remove('text-danger');
+        return;
+    }
+
+    const capacity = calculateRoomRequestCapacityClient(requests);
+    if (capacity <= 0) {
+        reservationCapacityEl.textContent = 'Für die ausgewählten Kategorien ist keine Kapazität hinterlegt.';
+        reservationCapacityEl.classList.remove('text-danger');
+        return;
+    }
+
+    reservationCapacityEl.textContent = `Kapazität: ${guestTotal} von ${capacity} Gästen.`;
+    if (guestTotal > capacity) {
+        reservationCapacityEl.classList.add('text-danger');
+    } else {
+        reservationCapacityEl.classList.remove('text-danger');
+    }
+}
+
+function populateCompanyDropdowns() {
+    const companies = [...state.companies].sort((a, b) => (a.name || '').localeCompare(b.name || '', 'de', { sensitivity: 'base' }));
+
+    if (guestCompanySelect) {
+        const current = guestCompanySelect.value;
+        const options = ['<option value="">Keine Firma</option>'];
+        companies.forEach((company) => {
+            options.push(`<option value="${company.id}">${company.name || ''}</option>`);
+        });
+        guestCompanySelect.innerHTML = options.join('');
+        if (current && [...guestCompanySelect.options].some((option) => option.value === current)) {
+            guestCompanySelect.value = current;
+        }
+    }
+
+    if (reservationGuestCompanySelect) {
+        const current = reservationGuestCompanySelect.value;
+        const options = ['<option value="">Keine Firma</option>'];
+        companies.forEach((company) => {
+            options.push(`<option value="${company.id}">${company.name || ''}</option>`);
+        });
+        reservationGuestCompanySelect.innerHTML = options.join('');
+        if (current && [...reservationGuestCompanySelect.options].some((option) => option.value === current)) {
+            reservationGuestCompanySelect.value = current;
+        }
+    }
+}
+
+function renderReservationArticleOptions(selectedArticles = []) {
+    if (!reservationArticleContainer) {
+        return;
+    }
+    const activeArticles = state.articles.filter((article) => Number(article.is_active ?? 1) === 1);
+    if (activeArticles.length === 0) {
+        reservationArticleContainer.innerHTML = '<p class="muted">Keine Zusatzleistungen hinterlegt.</p>';
+        return;
+    }
+
+    const selectedMap = new Map();
+    selectedArticles.forEach((entry) => {
+        const articleId = Number(entry.article_id ?? entry.id);
+        if (!Number.isNaN(articleId)) {
+            const multiplier = Number(entry.multiplier ?? entry.quantity ?? 1);
+            selectedMap.set(articleId, Number.isFinite(multiplier) ? multiplier : 1);
+        }
+    });
+
+    const markup = activeArticles.map((article) => {
+        const id = Number(article.id);
+        const isSelected = selectedMap.has(id);
+        const multiplierValue = selectedMap.get(id) ?? 1;
+        const hint = formatArticleHint(article);
+        const description = article.description ? `<small>${escapeHtml(article.description)}</small>` : '';
+        return `
+            <div class="article-option" data-article-id="${id}">
+                <label>
+                    <input type="checkbox" value="${id}" ${isSelected ? 'checked' : ''}>
+                    <span>
+                        <strong>${escapeHtml(article.name || '')}</strong>
+                        ${description}
+                        <em>${escapeHtml(hint)}</em>
+                    </span>
+                </label>
+                <input type="number" class="article-multiplier" min="0" step="0.1" value="${Number(multiplierValue).toString()}" ${isSelected ? '' : 'disabled'}>
+            </div>
+        `;
+    }).join('');
+
+    reservationArticleContainer.innerHTML = markup;
+}
+
+function renderArticlesTable() {
+    if (!articlesList) {
+        return;
+    }
+    const columns = [
+        { key: 'name', label: 'Name', render: (row) => escapeHtml(row.name || '') },
+        { key: 'charge_scheme', label: 'Abrechnung', render: (row) => escapeHtml(formatChargeScheme(row.charge_scheme)) },
+        { key: 'unit_price', label: 'Preis', render: (row) => escapeHtml(formatCurrency(row.unit_price ?? 0, row.currency || 'EUR')) },
+        { key: 'tax_rate', label: 'MwSt', render: (row) => `${Number(row.tax_rate ?? 0).toFixed(1)} %` },
+        { key: 'is_active', label: 'Status', render: (row) => (Number(row.is_active ?? 1) ? 'Aktiv' : 'Inaktiv') },
+        {
+            key: 'actions',
+            label: 'Aktionen',
+            render: (row) => {
+                const id = escapeHtml(String(row.id));
+                const actions = [`<button type="button" class="text-link" data-action="edit-article" data-id="${id}">Bearbeiten</button>`];
+                if (Number(row.is_active ?? 1)) {
+                    actions.push(`<button type="button" class="text-link" data-action="deactivate-article" data-id="${id}">Deaktivieren</button>`);
+                } else {
+                    actions.push(`<button type="button" class="text-link" data-action="activate-article" data-id="${id}">Aktivieren</button>`);
+                }
+                return actions.join(' ');
+            },
+        },
+    ];
+    renderTable('articles-list', columns, state.articles, 'Noch keine Artikel erfasst.');
+}
+
+function resetArticleForm() {
+    if (!articleForm) {
+        return;
+    }
+    articleForm.reset();
+    state.editingArticleId = null;
+    if (articleSummary) {
+        articleSummary.textContent = 'Neuer Artikel';
+    }
+    if (articleCancelButton) {
+        articleCancelButton.classList.add('hidden');
+    }
+}
+
+function startArticleEdit(articleId) {
+    if (!articleForm) {
+        return;
+    }
+    const article = state.articles.find((entry) => Number(entry.id) === Number(articleId));
+    if (!article) {
+        showMessage('Artikel wurde nicht gefunden.', 'error');
+        return;
+    }
+    state.editingArticleId = Number(articleId);
+    articleForm.name.value = article.name || '';
+    articleForm.description.value = article.description || '';
+    if (articleForm.charge_scheme) {
+        articleForm.charge_scheme.value = article.charge_scheme || 'per_person_per_day';
+    }
+    articleForm.unit_price.value = Number(article.unit_price ?? 0).toFixed(2);
+    articleForm.tax_rate.value = Number(article.tax_rate ?? 0).toFixed(1);
+    if (articleForm.is_active) {
+        articleForm.is_active.checked = Number(article.is_active ?? 1) === 1;
+    }
+    if (articleSummary) {
+        articleSummary.textContent = `Artikel bearbeiten (${article.name || ''})`;
+    }
+    if (articleCancelButton) {
+        articleCancelButton.classList.remove('hidden');
+    }
+    const section = articleForm.closest('.panel');
+    if (section && typeof section.scrollIntoView === 'function') {
+        section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+}
+
+function formatGuestLabel(guest) {
+    const parts = [];
+    if (guest?.last_name) {
+        parts.push(guest.last_name);
+    }
+    if (guest?.first_name) {
+        parts.push(guest.first_name);
+    }
+    let label = parts.join(', ').trim();
+    if (!label && guest?.email) {
+        label = guest.email;
+    }
+    if (!label && guest?.phone) {
+        label = guest.phone;
+    }
+    if (!label && guest?.id) {
+        label = `Gast #${guest.id}`;
+    }
+    if (guest?.company_name) {
+        label = `${label}${label ? ' – ' : ''}${guest.company_name}`;
+    }
+    return label;
+}
+
+function hideGuestSuggestions() {
+    if (!guestSearchResults) {
+        return;
+    }
+    guestSearchResults.classList.add('hidden');
+    guestSearchResults.innerHTML = '';
+}
+
+function renderGuestSuggestions(results, term) {
+    if (!guestSearchResults) {
+        return;
+    }
+    const normalizedTerm = (term || '').trim();
+    if (!normalizedTerm) {
+        hideGuestSuggestions();
+        return;
+    }
+    if (!Array.isArray(results) || results.length === 0) {
+        guestSearchResults.innerHTML = '<p class="muted small-text">Keine Treffer</p>';
+        guestSearchResults.classList.remove('hidden');
+        return;
+    }
+    const items = results.map((guest) => {
+        const label = formatGuestLabel(guest);
+        const metaParts = [];
+        if (guest.email) {
+            metaParts.push(guest.email);
+        }
+        if (guest.phone) {
+            metaParts.push(guest.phone);
+        }
+        const meta = metaParts.join(' · ');
+        return `
+            <button type="button" class="guest-suggestion" data-guest-id="${escapeHtml(String(guest.id))}">
+                <span class="guest-suggestion-name">${escapeHtml(label)}</span>
+                ${meta ? `<span class="guest-suggestion-meta">${escapeHtml(meta)}</span>` : ''}
+            </button>
+        `;
+    }).join('');
+    guestSearchResults.innerHTML = items;
+    guestSearchResults.classList.remove('hidden');
+}
+
+function setGuestSelection(guest) {
+    if (guestIdInput) {
+        guestIdInput.value = guest?.id ? String(guest.id) : '';
+    }
+    const label = guest ? formatGuestLabel(guest) : '';
+    if (guestSearchInput) {
+        guestSearchInput.value = label;
+        if (guest?.id) {
+            guestSearchInput.dataset.selectedId = String(guest.id);
+            guestSearchInput.dataset.selectedLabel = label;
+        } else {
+            delete guestSearchInput.dataset.selectedId;
+            delete guestSearchInput.dataset.selectedLabel;
+        }
+    }
+    if (guest?.id && !state.guests.some((entry) => Number(entry.id) === Number(guest.id))) {
+        state.guests.push({ ...guest });
+    }
+    fillGuestFields(guest);
+    if (guestClearSelectionButton) {
+        if (guest?.id) {
+            guestClearSelectionButton.classList.remove('hidden');
+        } else {
+            guestClearSelectionButton.classList.add('hidden');
+        }
+    }
+}
+
+function clearGuestSelection() {
+    setGuestSelection(null);
+    hideGuestSuggestions();
+    if (guestSearchInput) {
+        guestSearchInput.focus();
+    }
+}
+
+async function performGuestLookup(term, requestId) {
+    const normalizedTerm = term.trim();
+    if (!normalizedTerm || normalizedTerm.length < 2) {
+        state.guestLookupResults = [];
+        state.guestLookupTerm = normalizedTerm;
+        hideGuestSuggestions();
+        return;
+    }
+    try {
+        const response = await apiFetch(`guests?search=${encodeURIComponent(normalizedTerm)}&limit=10`);
+        if (requestId !== guestLookupRequestId) {
+            return;
+        }
+        const currentValue = guestSearchInput ? guestSearchInput.value.trim() : '';
+        if (currentValue !== normalizedTerm) {
+            return;
+        }
+        state.guestLookupResults = Array.isArray(response) ? response : [];
+        state.guestLookupTerm = normalizedTerm;
+        renderGuestSuggestions(state.guestLookupResults, normalizedTerm);
+    } catch (error) {
+        if (requestId === guestLookupRequestId) {
+            hideGuestSuggestions();
+            showMessage(error.message, 'error');
+        }
+    }
+}
+
+function scheduleGuestLookup(term) {
+    if (guestLookupDebounceId) {
+        clearTimeout(guestLookupDebounceId);
+    }
+    const normalizedTerm = (term || '').trim();
+    if (!normalizedTerm || normalizedTerm.length < 2) {
+        state.guestLookupResults = [];
+        state.guestLookupTerm = normalizedTerm;
+        hideGuestSuggestions();
+        return;
+    }
+    guestLookupDebounceId = setTimeout(() => {
+        guestLookupRequestId += 1;
+        performGuestLookup(normalizedTerm, guestLookupRequestId);
+    }, 200);
+}
+
+function fillGuestFields(guest) {
+    if (!reservationForm) {
+        return;
+    }
+    reservationForm.guest_first.value = guest?.first_name || '';
+    reservationForm.guest_last.value = guest?.last_name || '';
+    reservationForm.guest_email.value = guest?.email || '';
+    reservationForm.guest_phone.value = guest?.phone || '';
+    if (reservationGuestCompanySelect) {
+        reservationGuestCompanySelect.value = guest?.company_id ? String(guest.company_id) : '';
+    }
+}
+
+function resetReservationForm() {
+    if (!reservationForm) {
+        return;
+    }
+    const wasOpen = reservationDetails ? reservationDetails.open : false;
+    reservationForm.reset();
+    state.editingReservationId = null;
+    state.currentReservationInvoices = [];
+    if (reservationSummary) {
+        reservationSummary.textContent = 'Neue Reservierung anlegen';
+    }
+    if (reservationSubmitButton) {
+        reservationSubmitButton.textContent = 'Reservierung speichern';
+    }
+    if (reservationCancelButton) {
+        reservationCancelButton.classList.add('hidden');
+    }
+    ensureReservationReferenceData();
+    populateCompanyDropdowns();
+    renderReservationArticleOptions();
+    setReservationRoomRequests([]);
+    setGuestSelection(null);
+    hideGuestSuggestions();
+    if (reservationDetails) {
+        reservationDetails.open = wasOpen;
+    }
+    updateReservationCapacityHint();
+    updateReservationMeta(null);
+}
+
+function fillReservationForm(reservation) {
+    if (!reservationForm) {
+        return;
+    }
+    ensureReservationReferenceData();
+    populateCompanyDropdowns();
+
+    reservationForm.check_in.value = reservation.check_in_date ? reservation.check_in_date.slice(0, 10) : '';
+    reservationForm.check_out.value = reservation.check_out_date ? reservation.check_out_date.slice(0, 10) : '';
+    reservationForm.adults.value = reservation.adults ?? 1;
+    reservationForm.children.value = reservation.children ?? 0;
+    reservationForm.total_amount.value = reservation.total_amount ?? '';
+    reservationForm.currency.value = reservation.currency || 'EUR';
+    reservationForm.status.value = reservation.status || 'confirmed';
+    reservationForm.booked_via.value = reservation.booked_via || '';
+    const guestSnapshot = {
+        id: reservation.guest_id || null,
+        first_name: reservation.first_name || '',
+        last_name: reservation.last_name || '',
+        email: reservation.email || '',
+        phone: reservation.phone || '',
+        company_id: reservation.company_id || null,
+        company_name: reservation.company_name || null,
+    };
+
+    setGuestSelection(guestSnapshot);
+    renderReservationArticleOptions(reservation.articles || []);
+    const roomRequestSource = Array.isArray(reservation.room_requests) && reservation.room_requests.length
+        ? reservation.room_requests
+        : deriveRoomRequestsFromRooms(reservation.rooms || []);
+    setReservationRoomRequests(roomRequestSource);
+    updateReservationCapacityHint();
+    updateReservationMeta(reservation);
+}
+
+function formatReservationAssignment(row) {
+    const rooms = Array.isArray(row.rooms) ? row.rooms : [];
+    if (rooms.length) {
+        return rooms
+            .map((room) => {
+                const number = room.room_number || room.name || `Zimmer ${room.room_id ?? room.id ?? ''}`;
+                const typeName = room.room_type_name ? ` (${room.room_type_name})` : '';
+                return escapeHtml(`${number}${typeName}`);
+            })
+            .join('<br>');
+    }
+
+    const requests = Array.isArray(row.room_requests) ? row.room_requests : [];
+    if (requests.length) {
+        const lines = requests
+            .map((request) => {
+                const type = request.room_type_name || getRoomTypeById(request.room_type_id)?.name || `Kategorie ${request.room_type_id}`;
+                const quantity = Number(request.quantity ?? 1);
+                const suffix = Number.isFinite(quantity) && quantity > 1 ? ` × ${quantity}` : '';
+                return `<div>${escapeHtml(`${type}${suffix}`)}</div>`;
+            })
+            .join('');
+        return `<div><strong>Überbuchung</strong>${lines}</div>`;
+    }
+
+    return '<span class="muted small-text">Noch nicht zugewiesen</span>';
+}
+
+async function startReservationEdit(reservationId) {
+    if (!requireToken()) {
+        return;
+    }
+    try {
+        const reservation = await apiFetch(`reservations/${reservationId}`);
+        if (!reservation) {
+            showMessage('Reservierung konnte nicht geladen werden.', 'error');
+            return;
+        }
+        state.editingReservationId = reservation.id;
+        if (reservationSummary) {
+            const label = reservation.confirmation_number || `ID ${reservation.id}`;
+            reservationSummary.textContent = `Reservierung bearbeiten (${label})`;
+        }
+        if (reservationSubmitButton) {
+            reservationSubmitButton.textContent = 'Reservierung aktualisieren';
+        }
+        if (reservationCancelButton) {
+            reservationCancelButton.classList.remove('hidden');
+        }
+        if (reservationDetails) {
+            reservationDetails.open = true;
+        }
+        fillReservationForm(reservation);
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+function renderReservationsTable(reservations) {
+    renderTable('reservations-list', [
+        { key: 'confirmation_number', label: 'Bestätigungsnr.' },
+        {
+            key: 'guest',
+            label: 'Gast',
+            render: (row) => {
+                const guestName = `${row.first_name || ''} ${row.last_name || ''}`.trim();
+                if (row.company_name) {
+                    return `${guestName || ''}<div class="table-subline">${row.company_name}</div>`;
+                }
+                return guestName;
+            },
+        },
+        { key: 'check_in_date', label: 'Check-in', render: (row) => formatDate(row.check_in_date) },
+        { key: 'check_out_date', label: 'Check-out', render: (row) => formatDate(row.check_out_date) },
+        { key: 'status', label: 'Status', render: (row) => formatReservationStatus(row.status) },
+        { key: 'rooms', label: 'Zuweisung', render: (row) => formatReservationAssignment(row) },
+        { key: 'total_amount', label: 'Gesamt', render: (row) => formatCurrency(row.total_amount, row.currency || 'EUR') },
+        {
+            key: 'actions',
+            label: 'Aktionen',
+            render: (row) => renderReservationActions(row),
+        },
+    ], reservations);
+}
+
+function renderReservationActions(row) {
+    const status = normalizeStatusClass(row.status || '');
+    const buttons = RESERVATION_STATUS_ACTIONS.map((action) => {
+        const token = getCalendarColorToken(action.status);
+        const isDisabled = status === action.status;
+        const style = `--action-color:${token.color};--action-border:${token.border};--action-text:${token.text};`;
+        const titleAttr = action.title ? ` title="${action.title}"` : '';
+        return `<button type="button" class="reservation-status status-action" data-id="${row.id}" data-status="${action.status}" style="${style}"${titleAttr}${isDisabled ? ' disabled' : ''}>${action.label}</button>`;
+    }).join('');
+
+    return `<div class="table-actions">${buttons}<button type="button" class="secondary reservation-edit" data-id="${row.id}">Bearbeiten</button></div>`;
+}
+
+async function updateReservationStatus(reservationId, status) {
+    if (!requireToken()) {
+        return;
+    }
+    try {
+        await apiFetch(`reservations/${reservationId}/status`, {
+            method: 'POST',
+            body: JSON.stringify({ status }),
+        });
+        showMessage('Reservierungsstatus aktualisiert.', 'success');
+        await Promise.all([
+            loadReservations(true),
+            loadDashboard(true),
+        ]);
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+function renderGuestsTable(guests) {
+    renderTable('guests-list', [
+        { key: 'last_name', label: 'Nachname' },
+        { key: 'first_name', label: 'Vorname' },
+        { key: 'company_name', label: 'Firma' },
+        { key: 'email', label: 'E-Mail' },
+        { key: 'phone', label: 'Telefon' },
+        { key: 'notes', label: 'Notizen' },
+        { key: 'actions', label: 'Aktionen', render: (row) => `<button type="button" class="secondary guest-edit" data-id="${row.id}">Bearbeiten</button>` },
+    ], guests);
+}
+
+function renderCompaniesTable(companies) {
+    renderTable('companies-list', [
+        { key: 'name', label: 'Name' },
+        { key: 'email', label: 'E-Mail' },
+        { key: 'phone', label: 'Telefon' },
+        { key: 'city', label: 'Stadt' },
+        { key: 'country', label: 'Land' },
+        { key: 'notes', label: 'Notizen' },
+        { key: 'actions', label: 'Aktionen', render: (row) => `<button type="button" class="secondary company-edit" data-id="${row.id}">Bearbeiten</button>` },
+    ], companies);
+}
+
+function resetGuestForm() {
+    if (!guestForm) {
+        return;
+    }
+    const wasOpen = guestDetails ? guestDetails.open : false;
+    guestForm.reset();
+    state.editingGuestId = null;
+    if (guestSubmitButton) {
+        guestSubmitButton.textContent = 'Gast speichern';
+    }
+    if (guestCancelButton) {
+        guestCancelButton.classList.add('hidden');
+    }
+    if (guestSummary) {
+        guestSummary.textContent = guestSummaryDefault;
+    }
+    populateCompanyDropdowns();
+    if (guestCompanySelect) {
+        guestCompanySelect.value = '';
+    }
+    if (guestDetails) {
+        guestDetails.open = wasOpen;
+    }
+}
+
+function startGuestEdit(guestId) {
+    if (!guestForm) {
+        return;
+    }
+    const guest = state.guests.find((entry) => Number(entry.id) === Number(guestId));
+    if (!guest) {
+        showMessage('Gast wurde nicht gefunden.', 'error');
+        return;
+    }
+    populateCompanyDropdowns();
+    guestForm.first_name.value = guest.first_name || '';
+    guestForm.last_name.value = guest.last_name || '';
+    guestForm.email.value = guest.email || '';
+    guestForm.phone.value = guest.phone || '';
+    guestForm.address.value = guest.address || '';
+    guestForm.city.value = guest.city || '';
+    guestForm.country.value = guest.country || '';
+    guestForm.notes.value = guest.notes || '';
+    if (guestCompanySelect) {
+        guestCompanySelect.value = guest.company_id ? String(guest.company_id) : '';
+    }
+    state.editingGuestId = Number(guest.id);
+    if (guestSubmitButton) {
+        guestSubmitButton.textContent = 'Gast aktualisieren';
+    }
+    if (guestCancelButton) {
+        guestCancelButton.classList.remove('hidden');
+    }
+    if (guestSummary) {
+        const label = [guest.last_name, guest.first_name].filter(Boolean).join(', ') || `ID ${guest.id}`;
+        guestSummary.textContent = `Gast bearbeiten (${label})`;
+    }
+    if (guestDetails) {
+        guestDetails.open = true;
+    }
+}
+
+function resetCompanyForm() {
+    if (!companyForm) {
+        return;
+    }
+    const wasOpen = companyDetails ? companyDetails.open : false;
+    companyForm.reset();
+    state.editingCompanyId = null;
+    if (companySubmitButton) {
+        companySubmitButton.textContent = 'Firma speichern';
+    }
+    if (companyCancelButton) {
+        companyCancelButton.classList.add('hidden');
+    }
+    if (companySummary) {
+        companySummary.textContent = companySummaryDefault;
+    }
+    if (companyDetails) {
+        companyDetails.open = wasOpen;
+    }
+}
+
+function startCompanyEdit(companyId) {
+    if (!companyForm) {
+        return;
+    }
+    const company = state.companies.find((entry) => Number(entry.id) === Number(companyId));
+    if (!company) {
+        showMessage('Firma wurde nicht gefunden.', 'error');
+        return;
+    }
+    companyForm.name.value = company.name || '';
+    companyForm.email.value = company.email || '';
+    companyForm.phone.value = company.phone || '';
+    companyForm.address.value = company.address || '';
+    companyForm.city.value = company.city || '';
+    companyForm.country.value = company.country || '';
+    companyForm.notes.value = company.notes || '';
+    state.editingCompanyId = Number(company.id);
+    if (companySubmitButton) {
+        companySubmitButton.textContent = 'Firma aktualisieren';
+    }
+    if (companyCancelButton) {
+        companyCancelButton.classList.remove('hidden');
+    }
+    if (companySummary) {
+        const label = company.name || `ID ${company.id}`;
+        companySummary.textContent = `Firma bearbeiten (${label})`;
+    }
+    if (companyDetails) {
+        companyDetails.open = true;
+    }
+}
+
+function renderOccupancyCalendar(rooms, reservations, startDateStr, days = CALENDAR_DAYS, labelMode = state.calendarLabelMode || 'guest') {
+    const container = document.getElementById('occupancy-calendar');
+    if (!container) {
+        return;
+    }
+
+    container.innerHTML = '';
+
+    if (!rooms || rooms.length === 0) {
+        const empty = document.createElement('p');
+        empty.className = 'muted';
+        empty.textContent = 'Bitte legen Sie Zimmer an, um die Belegung anzuzeigen.';
+        container.appendChild(empty);
+        return;
+    }
+
+    const startDate = parseISODate(startDateStr) || new Date();
+    const totalDays = Number.isFinite(days) && days > 0 ? Math.floor(days) : CALENDAR_DAYS;
+    const dayDates = [];
+    for (let index = 0; index < totalDays; index += 1) {
+        dayDates.push(addDays(startDate, index));
+    }
+    const dayKeys = dayDates.map((date) => dateKey(date));
+    const dayKeySet = new Set(dayKeys);
+    const rangeEndExclusive = addDays(startDate, totalDays);
+    const occupancyMap = new Map();
+    const overbookingRows = new Map();
+    const reservationsList = Array.isArray(reservations) ? reservations : [];
+
+    const pushEntry = (rowId, dateKeyValue, entry) => {
+        const mapKey = `${rowId}_${dateKeyValue}`;
+        const bucket = occupancyMap.get(mapKey);
+        if (bucket) {
+            bucket.push(entry);
+        } else {
+            occupancyMap.set(mapKey, [entry]);
+        }
+    };
+
+    reservationsList.forEach((reservation) => {
+        const statusClass = normalizeStatusClass(reservation.status || '');
+        if (statusClass === 'cancelled') {
+            return;
+        }
+        const checkIn = parseISODate(reservation.check_in_date);
+        const checkOut = parseISODate(reservation.check_out_date);
+        if (!checkIn || !checkOut || checkOut <= checkIn) {
+            return;
+        }
+        const visibleStart = checkIn > startDate ? checkIn : startDate;
+        const visibleEnd = checkOut < rangeEndExclusive ? checkOut : rangeEndExclusive;
+        if (visibleEnd <= visibleStart) {
+            return;
+        }
+
+        const requestList = Array.isArray(reservation.room_requests) ? reservation.room_requests : [];
+
+        (reservation.rooms || []).forEach((room) => {
+            const roomId = room.room_id ?? room.id;
+            if (!roomId) {
+                return;
+            }
+            const rowKey = `room-${roomId}`;
+            for (let cursor = new Date(visibleStart); cursor < visibleEnd; cursor = addDays(cursor, 1)) {
+                const keyDate = dateKey(cursor);
+                if (!dayKeySet.has(keyDate)) {
+                    continue;
+                }
+                pushEntry(rowKey, keyDate, {
+                    reservation,
+                    statusClass,
+                    roomTypeName: room.room_type_name || null,
+                    isOverbooking: false,
+                    quantity: 1,
+                });
+            }
+        });
+
+        requestList.forEach((request) => {
+            const typeId = Number(request.room_type_id ?? request.id ?? 0);
+            if (!Number.isFinite(typeId) || typeId <= 0) {
+                return;
+            }
+            const quantity = Number(request.quantity ?? 1);
+            const normalizedQuantity = Number.isFinite(quantity) && quantity > 0 ? quantity : 1;
+            const rowKey = `overbook-${typeId}`;
+            if (!overbookingRows.has(rowKey)) {
+                const roomType = getRoomTypeById(typeId);
+                const typeName = roomType?.name || request.room_type_name || `Kategorie ${typeId}`;
+                overbookingRows.set(rowKey, {
+                    calendar_id: rowKey,
+                    room_type_id: typeId,
+                    room_type_name: typeName,
+                    label: `Überbuchung – ${typeName}`,
+                    isOverbooking: true,
+                });
+            }
+            const roomTypeName = getRoomTypeById(typeId)?.name || request.room_type_name || `Kategorie ${typeId}`;
+            for (let cursor = new Date(visibleStart); cursor < visibleEnd; cursor = addDays(cursor, 1)) {
+                const keyDate = dateKey(cursor);
+                if (!dayKeySet.has(keyDate)) {
+                    continue;
+                }
+                pushEntry(rowKey, keyDate, {
+                    reservation,
+                    statusClass,
+                    roomTypeName,
+                    isOverbooking: true,
+                    quantity: normalizedQuantity,
+                });
+            }
+        });
+    });
+
+    const table = document.createElement('table');
+    table.className = 'calendar-table';
+    const thead = document.createElement('thead');
+    const headerRow = document.createElement('tr');
+    const roomHeader = document.createElement('th');
+    roomHeader.className = 'room';
+    roomHeader.textContent = 'Zimmer';
+    headerRow.appendChild(roomHeader);
+
+    const headerFormatter = new Intl.DateTimeFormat('de-DE', { weekday: 'short', day: '2-digit', month: '2-digit' });
+    const todayKey = toLocalISODate();
+
+    dayDates.forEach((date) => {
+        const th = document.createElement('th');
+        const key = dateKey(date);
+        th.textContent = headerFormatter.format(date);
+        th.dataset.date = key;
+        if (key === todayKey) {
+            th.classList.add('today');
+        }
+        if (isWeekend(date)) {
+            th.classList.add('weekend');
+        }
+        headerRow.appendChild(th);
+    });
+
+    thead.appendChild(headerRow);
+    table.appendChild(thead);
+
+    const tbody = document.createElement('tbody');
+    const sortedRooms = [...rooms].sort((a, b) => {
+        const typeCompare = (a.room_type_name || '').localeCompare(b.room_type_name || '', 'de', { sensitivity: 'base' });
+        if (typeCompare !== 0) {
+            return typeCompare;
+        }
+        const aValue = (a.room_number ?? a.name ?? '').toString();
+        const bValue = (b.room_number ?? b.name ?? '').toString();
+        return aValue.localeCompare(bValue, 'de', { numeric: true, sensitivity: 'base' });
+    });
+
+    const calendarRows = sortedRooms.map((room) => {
+        const roomId = room.id ?? room.room_id;
+        return {
+            calendar_id: `room-${roomId}`,
+            label: room.room_type_name ? `${room.room_number || room.name || `Zimmer ${roomId}`} (${room.room_type_name})` : (room.room_number || room.name || `Zimmer ${roomId}`),
+            isOverbooking: false,
+        };
+    });
+
+    const overbookingRowList = Array.from(overbookingRows.values()).sort((a, b) => (a.room_type_name || '').localeCompare(b.room_type_name || '', 'de', { sensitivity: 'base' }));
+
+    [...calendarRows, ...overbookingRowList].forEach((rowInfo) => {
+        const row = document.createElement('tr');
+        if (rowInfo.isOverbooking) {
+            row.classList.add('overbooking-row');
+        }
+        const roomCell = document.createElement('th');
+        roomCell.scope = 'row';
+        roomCell.className = 'room';
+        roomCell.textContent = rowInfo.label;
+        if (rowInfo.isOverbooking) {
+            roomCell.classList.add('overbooking');
+        }
+        row.appendChild(roomCell);
+
+        dayDates.forEach((date) => {
+            const key = `${rowInfo.calendar_id}_${dateKey(date)}`;
+            const cell = document.createElement('td');
+            cell.dataset.date = dateKey(date);
+            if (cell.dataset.date === todayKey) {
+                cell.classList.add('today');
+            }
+            if (isWeekend(date)) {
+                cell.classList.add('weekend');
+            }
+
+            const entries = occupancyMap.get(key) || [];
+            if (entries.length > 0) {
+                cell.classList.add('occupied');
+                if (entries.length > 1) {
+                    cell.classList.add('multi');
+                }
+                const firstEntry = entries[0];
+                if (firstEntry.statusClass) {
+                    cell.classList.add(`status-${firstEntry.statusClass}`);
+                    cell.dataset.status = firstEntry.statusClass;
+                }
+                if (firstEntry.reservation?.id) {
+                    cell.dataset.reservationId = String(firstEntry.reservation.id);
+                } else {
+                    delete cell.dataset.reservationId;
+                }
+                cell.textContent = '';
+                entries.forEach((entry) => {
+                    const entryDiv = document.createElement('div');
+                    entryDiv.className = 'calendar-entry';
+                    if (entry.statusClass) {
+                        entryDiv.classList.add(`status-${entry.statusClass}`);
+                    }
+                    if (entry.isOverbooking) {
+                        entryDiv.classList.add('overbooking');
+                    }
+                    if (entry.reservation?.id) {
+                        entryDiv.dataset.reservationId = String(entry.reservation.id);
+                    }
+                    const label = getReservationCalendarLabel(entry.reservation, labelMode);
+                    const quantitySuffix = entry.isOverbooking && entry.quantity > 1 ? ` ×${entry.quantity}` : '';
+                    const typeSuffix = entry.isOverbooking && entry.roomTypeName ? ` • ${entry.roomTypeName}` : '';
+                    entryDiv.textContent = `${label}${quantitySuffix}${typeSuffix}`;
+                    const guestName = `${entry.reservation.first_name || ''} ${entry.reservation.last_name || ''}`.trim();
+                    const statusLabel = formatReservationStatus(entry.reservation.status);
+                    const details = [
+                        label !== guestName && guestName ? `Gast: ${guestName}` : guestName,
+                        entry.reservation.company_name ? `Firma: ${entry.reservation.company_name}` : null,
+                        entry.reservation.confirmation_number ? `Bestätigungsnr.: ${entry.reservation.confirmation_number}` : null,
+                        statusLabel ? `Status: ${statusLabel}` : null,
+                        entry.reservation.check_in_date ? `Anreise: ${formatDate(entry.reservation.check_in_date)}` : null,
+                        entry.reservation.check_out_date ? `Abreise: ${formatDate(entry.reservation.check_out_date)}` : null,
+                        entry.isOverbooking && entry.roomTypeName ? `Kategorie: ${entry.roomTypeName}` : null,
+                        entry.isOverbooking && entry.quantity > 1 ? `Einheiten: ${entry.quantity}` : null,
+                    ].filter(Boolean);
+                    if (details.length) {
+                        entryDiv.title = details.join('\n');
+                    }
+                    cell.appendChild(entryDiv);
+                });
+            } else {
+                cell.classList.add('vacant');
+                cell.textContent = rowInfo.isOverbooking ? 'Keine Überbuchung' : 'Frei';
+                delete cell.dataset.reservationId;
+            }
+            row.appendChild(cell);
+        });
+
+        tbody.appendChild(row);
+    });
+
+    table.appendChild(tbody);
+    container.appendChild(table);
+}
+
+async function bootstrap() {
+    if (!requireToken()) {
+        return;
+    }
+    try {
+        const [roomTypes, ratePlans, rooms, roles, guests, companies, articles, logoResponse] = await Promise.all([
+            apiFetch('room-types'),
+            apiFetch('rate-plans'),
+            apiFetch('rooms'),
+            apiFetch('roles'),
+            apiFetch('guests'),
+            apiFetch('companies'),
+            apiFetch('articles?include_inactive=1'),
+            apiFetch('settings/invoice-logo'),
+        ]);
+        state.roomTypes = roomTypes;
+        state.ratePlans = ratePlans;
+        state.rooms = rooms;
+        state.roles = roles;
+        state.guests = guests;
+        state.companies = companies;
+        state.companiesLoaded = true;
+        state.articles = Array.isArray(articles) ? articles : [];
+        state.articlesLoaded = true;
+        const logoData = logoResponse && typeof logoResponse === 'object' ? logoResponse.logo || null : null;
+        updateInvoiceLogoPreview(logoData);
+        await loadCalendarColors(true);
+        populateRoomTypeSelects();
+        populateRoomOptions();
+        populateRoleCheckboxes();
+        populateRoomTypeList();
+        populateRatePlanList();
+        populateCompanyDropdowns();
+        renderArticlesTable();
+        renderGuestsTable(guests);
+        renderCompaniesTable(companies);
+        resetReservationForm();
+        state.loadedSections.clear();
+        await Promise.all([
+            loadDashboard(true),
+            loadReservations(true),
+            loadRooms(true),
+            loadHousekeeping(true),
+        ]);
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+function populateRoomTypeSelects() {
+    const sortedTypes = [...state.roomTypes].sort((a, b) => (a.name || '').localeCompare(b.name || '', 'de', { sensitivity: 'base' }));
+    const roomSelect = document.querySelector('#room-form select[name="room_type"]');
+    if (roomSelect) {
+        roomSelect.innerHTML = sortedTypes.map((type) => `<option value="${type.id}">${type.name}</option>`).join('');
+    }
+    if (roomRequestTypeSelect) {
+        const previousValue = roomRequestTypeSelect.value;
+        const options = sortedTypes.map((type) => `<option value="${type.id}">${type.name}</option>`);
+        roomRequestTypeSelect.innerHTML = `<option value="">Kategorie wählen</option>${options.join('')}`;
+        if (previousValue && [...roomRequestTypeSelect.options].some((option) => option.value === previousValue)) {
+            roomRequestTypeSelect.value = previousValue;
+        }
+    }
+    renderReservationRoomRequests();
+}
+
+function populateRoomOptions() {
+    const taskRoomSelect = document.querySelector('#task-form select[name="room"]');
+    const sortedRooms = [...state.rooms].sort((a, b) => {
+        const typeCompare = (a.room_type_name || '').localeCompare(b.room_type_name || '', 'de', { sensitivity: 'base' });
+        if (typeCompare !== 0) {
+            return typeCompare;
+        }
+        const aValue = (a.room_number ?? a.name ?? '').toString();
+        const bValue = (b.room_number ?? b.name ?? '').toString();
+        return aValue.localeCompare(bValue, 'de', { numeric: true, sensitivity: 'base' });
+    });
+    const options = sortedRooms.map((room) => {
+        const capacity = Number(room.max_occupancy ?? room.base_occupancy ?? 0);
+        const capacityText = capacity > 0 ? ` • max. ${capacity}` : '';
+        const typeLabel = room.room_type_name || 'Kategorie';
+        return `<option value="${room.id}">${room.room_number} (${typeLabel}${capacityText})</option>`;
+    });
+    if (taskRoomSelect) {
+        taskRoomSelect.innerHTML = `<option value="">Kein Zimmer</option>${options.join('')}`;
+    }
+    updateReservationCapacityHint();
+}
+
+async function ensureReservationReferenceData(force = false) {
+    if (!state.token) {
+        populateRoomOptions();
+        populateRoomTypeSelects();
+        return;
+    }
+
+    const loaders = [];
+    if (force || state.roomTypes.length === 0) {
+        loaders.push(
+            apiFetch('room-types')
+                .then((roomTypes) => {
+                    state.roomTypes = Array.isArray(roomTypes) ? roomTypes : [];
+                })
+                .catch((error) => {
+                    showMessage(error.message, 'error');
+                }),
+        );
+    }
+    if (force || state.ratePlans.length === 0) {
+        loaders.push(
+            apiFetch('rate-plans')
+                .then((ratePlans) => {
+                    state.ratePlans = Array.isArray(ratePlans) ? ratePlans : [];
+                })
+                .catch((error) => {
+                    showMessage(error.message, 'error');
+                }),
+        );
+    }
+    if (force || state.rooms.length === 0) {
+        loaders.push(
+            apiFetch('rooms')
+                .then((rooms) => {
+                    state.rooms = Array.isArray(rooms) ? rooms : [];
+                })
+                .catch((error) => {
+                    showMessage(error.message, 'error');
+                }),
+        );
+    }
+
+    if (loaders.length) {
+        await Promise.all(loaders);
+    }
+
+    populateRoomOptions();
+    populateRoomTypeSelects();
+}
+
+function populateRoleCheckboxes() {
+    const container = document.getElementById('user-roles');
+    if (!container) {
+        return;
+    }
+    container.innerHTML = '';
+    state.roles.forEach((role) => {
+        const label = document.createElement('label');
+        const input = document.createElement('input');
+        input.type = 'checkbox';
+        input.value = role.id;
+        label.appendChild(input);
+        label.append(` ${role.name}`);
+        container.appendChild(label);
+    });
+}
+
+function populateRoomTypeList() {
+    renderTable('room-types-list', [
+        { key: 'name', label: 'Name' },
+        { key: 'base_rate', label: 'Grundpreis', render: (row) => formatCurrency(row.base_rate, row.currency || 'EUR') },
+    ], state.roomTypes);
+}
+
+function populateRatePlanList() {
+    renderTable('rate-plans-list', [
+        { key: 'name', label: 'Name' },
+        { key: 'base_price', label: 'Grundpreis', render: (row) => formatCurrency(row.base_price, row.currency || 'EUR') },
+        { key: 'cancellation_policy', label: 'Stornobedingungen' },
+    ], state.ratePlans);
+}
+
+async function loadDashboard(force = false) {
+    if (!requireToken()) {
+        return;
+    }
+    if (!force && state.loadedSections.has('dashboard')) {
+        return;
+    }
+    try {
+        const targetDateValue = dashboardDateInput.value || toLocalISODate();
+        const targetDate = parseISODate(targetDateValue) || new Date();
+        const monthStart = toLocalISODate(new Date(targetDate.getFullYear(), targetDate.getMonth(), 1));
+        const monthEnd = toLocalISODate(new Date(targetDate.getFullYear(), targetDate.getMonth() + 1, 0));
+        const calendarEnd = toLocalISODate(addDays(targetDate, CALENDAR_DAYS - 1));
+
+        const roomsPromise = state.rooms.length
+            ? Promise.resolve(state.rooms)
+            : apiFetch('rooms').then((rooms) => {
+                state.rooms = rooms;
+                populateRoomOptions();
+                return rooms;
+            });
+
+        const reservationsPromise = force || state.reservations.length === 0
+            ? apiFetch('reservations').then((reservations) => {
+                state.reservations = reservations;
+                return reservations;
+            })
+            : Promise.resolve(state.reservations);
+
+        const [occupancy, revenue, openTasks, rooms, reservations] = await Promise.all([
+            apiFetch(`reports/occupancy?start=${targetDateValue}&end=${calendarEnd}`),
+            apiFetch(`reports/revenue?start=${monthStart}&end=${monthEnd}`),
+            apiFetch('housekeeping/tasks?status=open'),
+            roomsPromise,
+            reservationsPromise,
+        ]);
+
+        if (Array.isArray(rooms)) {
+            state.rooms = rooms;
+        }
+        state.reservations = Array.isArray(reservations) ? reservations : [];
+
+        if (state.loadedSections.has('reservations')) {
+            renderReservationsTable(state.reservations);
+        }
+
+        const occupancyToday = Array.isArray(occupancy)
+            ? occupancy.find((entry) => entry.date === targetDateValue) || null
+            : null;
+        document.getElementById('dash-occupancy-rate').textContent = occupancyToday ? `${occupancyToday.occupancy_rate}%` : '--%';
+        document.getElementById('dash-occupancy-detail').textContent = occupancyToday
+            ? `${occupancyToday.occupied_rooms} von ${occupancyToday.available_rooms} Zimmern belegt`
+            : 'Keine Daten';
+
+        const invoiceTotals = revenue?.invoices || { invoice_total: 0, tax_total: 0 };
+        document.getElementById('dash-revenue-total').textContent = formatCurrency(invoiceTotals.invoice_total || 0);
+        document.getElementById('dash-revenue-detail').textContent = `Steueranteil: ${formatCurrency(invoiceTotals.tax_total || 0)}`;
+
+        const openTaskCount = Array.isArray(openTasks) ? openTasks.length : 0;
+        document.getElementById('dash-open-tasks').textContent = openTaskCount;
+
+        renderTable('occupancy-table', [
+            { key: 'date', label: 'Datum', render: (row) => formatDate(row.date) },
+            { key: 'occupied_rooms', label: 'Belegte Zimmer' },
+            { key: 'available_rooms', label: 'Gesamtzimmer' },
+            { key: 'occupancy_rate', label: 'Auslastung', render: (row) => `${row.occupancy_rate}%` },
+        ], Array.isArray(occupancy) ? occupancy : []);
+
+        renderOccupancyCalendar(rooms, reservations, targetDateValue, CALENDAR_DAYS, state.calendarLabelMode);
+        state.loadedSections.add('dashboard');
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+
+async function loadReservations(force = false) {
+    if (!requireToken()) {
+        return;
+    }
+    await ensureReservationReferenceData(force);
+    if (!force && state.loadedSections.has('reservations')) {
+        return;
+    }
+    try {
+        const reservations = await apiFetch('reservations');
+        state.reservations = reservations;
+        renderReservationsTable(reservations);
+        state.loadedSections.add('reservations');
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+async function loadCalendarColors(force = false) {
+    if (!requireToken()) {
+        return null;
+    }
+    if (!force && state.calendarColorsLoaded) {
+        return state.calendarColors;
+    }
+    try {
+        const response = await apiFetch('settings/calendar-colors');
+        const colors = response && typeof response.colors === 'object' ? response.colors : {};
+        applyCalendarColors({ ...CALENDAR_COLOR_DEFAULTS, ...colors });
+        state.calendarColorsLoaded = true;
+        return state.calendarColors;
+    } catch (error) {
+        showMessage(error.message, 'error');
+        return state.calendarColors;
+    }
+}
+
+async function loadSettings(force = false) {
+    if (!requireToken()) {
+        return;
+    }
+    if (!force && state.loadedSections.has('settings')) {
+        populateCalendarColorInputs();
+        updateInvoiceLogoPreview(state.invoiceLogoDataUrl);
+        return;
+    }
+    try {
+        const [, logoResponse] = await Promise.all([
+            loadCalendarColors(true),
+            apiFetch('settings/invoice-logo'),
+        ]);
+        populateCalendarColorInputs();
+        const logoData = logoResponse && typeof logoResponse === 'object' ? logoResponse.logo || null : null;
+        updateInvoiceLogoPreview(logoData);
+        state.loadedSections.add('settings');
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+async function loadArticles(force = false) {
+    if (!requireToken()) {
+        return;
+    }
+    if (!force && state.articlesLoaded) {
+        renderArticlesTable();
+        renderReservationArticleOptions();
+        return;
+    }
+    try {
+        const articles = await apiFetch('articles?include_inactive=1');
+        state.articles = Array.isArray(articles) ? articles : [];
+        state.articlesLoaded = true;
+        renderArticlesTable();
+        renderReservationArticleOptions();
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+async function loadRooms(force = false) {
+    if (!requireToken()) {
+        return;
+    }
+    if (!force && state.loadedSections.has('rooms')) {
+        return;
+    }
+    try {
+        const rooms = await apiFetch('rooms');
+        state.rooms = rooms;
+        populateRoomOptions();
+        renderTable('rooms-list', [
+            { key: 'room_number', label: 'Zimmer' },
+            { key: 'room_type_name', label: 'Kategorie' },
+            { key: 'floor', label: 'Etage' },
+            { key: 'status', label: 'Status' },
+            { key: 'notes', label: 'Notizen' },
+        ], rooms);
+        state.loadedSections.add('rooms');
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+async function loadHousekeeping(force = false) {
+    if (!requireToken()) {
+        return;
+    }
+    if (!force && state.loadedSections.has('housekeeping')) {
+        return;
+    }
+    try {
+        const tasks = await apiFetch('housekeeping/tasks');
+        renderTable('tasks-list', [
+            { key: 'title', label: 'Titel' },
+            { key: 'room_number', label: 'Zimmer' },
+            { key: 'status', label: 'Status' },
+            { key: 'due_date', label: 'Fällig', render: (row) => formatDateTime(row.due_date) },
+            { key: 'description', label: 'Beschreibung' },
+        ], tasks);
+        state.loadedSections.add('housekeeping');
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+async function loadBilling(force = false) {
+    if (!requireToken()) {
+        return;
+    }
+    if (!force && state.loadedSections.has('billing')) {
+        return;
+    }
+    try {
+        const [invoices, payments] = await Promise.all([
+            apiFetch('invoices'),
+            apiFetch('payments'),
+        ]);
+        await loadArticles(force);
+        renderTable('invoices-list', [
+            { key: 'invoice_number', label: 'Rechnungsnr.' },
+            { key: 'reservation_id', label: 'Reservierung' },
+            { key: 'issue_date', label: 'Ausgestellt am', render: (row) => formatDate(row.issue_date) },
+            { key: 'due_date', label: 'Fällig am', render: (row) => formatDate(row.due_date) },
+            { key: 'status', label: 'Status' },
+            { key: 'total_amount', label: 'Summe', render: (row) => formatCurrency(row.total_amount) },
+            {
+                key: 'actions',
+                label: 'Aktionen',
+                render: (row) => `<a href="${buildInvoicePdfUrl(row.id)}" target="_blank" rel="noopener">PDF</a>`,
+            },
+        ], invoices);
+        renderTable('payments-list', [
+            { key: 'invoice_number', label: 'Rechnungsnr.' },
+            { key: 'method', label: 'Methode' },
+            { key: 'amount', label: 'Betrag', render: (row) => formatCurrency(row.amount, row.currency || 'EUR') },
+            { key: 'paid_at', label: 'Bezahlt am', render: (row) => formatDateTime(row.paid_at) },
+            { key: 'reference', label: 'Referenz' },
+        ], payments);
+        state.loadedSections.add('billing');
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+async function loadReports(force = false) {
+    if (!requireToken()) {
+        return;
+    }
+    if (!force && state.loadedSections.has('reports')) {
+        return;
+    }
+    try {
+        const start = reportStartInput.value || toLocalISODate();
+        const end = reportEndInput.value || start;
+        const [occupancy, revenue, forecast] = await Promise.all([
+            apiFetch(`reports/occupancy?start=${start}&end=${end}`),
+            apiFetch(`reports/revenue?start=${start}&end=${end}`),
+            apiFetch(`reports/forecast?start=${start}&end=${end}`),
+        ]);
+        renderTable('report-occupancy', [
+            { key: 'date', label: 'Datum', render: (row) => formatDate(row.date) },
+            { key: 'occupied_rooms', label: 'Belegte Zimmer' },
+            { key: 'available_rooms', label: 'Gesamtzimmer' },
+            { key: 'occupancy_rate', label: 'Auslastung', render: (row) => `${row.occupancy_rate}%` },
+        ], occupancy);
+        renderTable('report-revenue', [
+            { key: 'metric', label: 'Kennzahl' },
+            { key: 'value', label: 'Wert' },
+        ], [
+            { metric: 'Rechnungsvolumen', value: formatCurrency(revenue?.invoices?.invoice_total || 0) },
+            { metric: 'Steueranteil', value: formatCurrency(revenue?.invoices?.tax_total || 0) },
+            { metric: 'Zahlungen (Summe)', value: formatCurrency((revenue?.payments || []).reduce((sum, payment) => sum + Number(payment.total_amount || payment.amount || 0), 0)) },
+        ]);
+        renderTable('report-forecast', [
+            { key: 'check_in_date', label: 'Check-in', render: (row) => formatDate(row.check_in_date) },
+            { key: 'check_out_date', label: 'Check-out', render: (row) => formatDate(row.check_out_date) },
+            { key: 'rooms', label: 'Zimmer' },
+            { key: 'total_amount', label: 'Erwarteter Umsatz', render: (row) => formatCurrency(row.total_amount) },
+        ], forecast?.reservations || []);
+        state.loadedSections.add('reports');
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+async function loadUsers(force = false) {
+    if (!requireToken()) {
+        return;
+    }
+    if (!force && state.loadedSections.has('users')) {
+        return;
+    }
+    try {
+        const [users, roles] = await Promise.all([
+            apiFetch('users'),
+            apiFetch('roles'),
+        ]);
+        state.roles = roles;
+        populateRoleCheckboxes();
+        renderTable('users-list', [
+            { key: 'name', label: 'Name' },
+            { key: 'email', label: 'E-Mail' },
+            { key: 'roles', label: 'Rollen', render: (row) => (row.roles || []).map((role) => role.name).join(', ') },
+            { key: 'created_at', label: 'Angelegt am', render: (row) => formatDateTime(row.created_at) },
+        ], users);
+        renderTable('roles-list', [
+            { key: 'name', label: 'Name' },
+            { key: 'description', label: 'Beschreibung' },
+        ], roles);
+        state.loadedSections.add('users');
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+async function fetchCompanies(force = false) {
+    if (!state.token) {
+        return [];
+    }
+    if (!force && state.companiesLoaded) {
+        return state.companies;
+    }
+    const companies = await apiFetch('companies');
+    state.companies = companies;
+    state.companiesLoaded = true;
+    populateCompanyDropdowns();
+    return companies;
+}
+
+async function loadGuests(force = false) {
+    if (!requireToken()) {
+        return;
+    }
+    if (!force && state.loadedSections.has('guests')) {
+        return;
+    }
+    try {
+        const [guests] = await Promise.all([
+            apiFetch('guests'),
+            fetchCompanies(force),
+        ]);
+        state.guests = guests;
+        populateCompanyDropdowns();
+        renderGuestsTable(guests);
+        state.loadedSections.add('guests');
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+async function loadCompanies(force = false) {
+    if (!requireToken()) {
+        return;
+    }
+    if (!force && state.loadedSections.has('companies')) {
+        return;
+    }
+    try {
+        const companies = await fetchCompanies(force);
+        renderCompaniesTable(companies);
+        state.loadedSections.add('companies');
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+async function loadIntegrations(force = false) {
+    if (!requireToken()) {
+        return;
+    }
+    if (!force && state.loadedSections.has('integrations')) {
+        return;
+    }
+    try {
+        const integrations = await apiFetch('integrations');
+        const container = document.getElementById('integrations-list');
+        container.innerHTML = '';
+        Object.entries(integrations).forEach(([key, value]) => {
+            const card = document.createElement('div');
+            card.className = 'integration-card';
+            card.innerHTML = `<h4>${key.replace(/_/g, ' ').toUpperCase()}</h4><p>Status: <strong>${value.status}</strong></p>${value.message ? `<p class="muted">${value.message}</p>` : ''}`;
+            container.appendChild(card);
+        });
+        state.loadedSections.add('integrations');
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+async function lookupGuestReservation(confirmation) {
+    try {
+        const reservation = await apiFetch(`guest-portal/reservations/${encodeURIComponent(confirmation)}`, { skipAuth: true });
+        renderTable('guest-portal-result', [
+            { key: 'confirmation_number', label: 'Bestätigungsnr.' },
+            { key: 'first_name', label: 'Vorname' },
+            { key: 'last_name', label: 'Nachname' },
+            { key: 'check_in_date', label: 'Check-in', render: (row) => formatDate(row.check_in_date) },
+            { key: 'check_out_date', label: 'Check-out', render: (row) => formatDate(row.check_out_date) },
+            { key: 'status', label: 'Status' },
+        ], reservation ? [reservation] : []);
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+}
+
+function addInvoiceItemRow() {
+    const container = document.getElementById('invoice-items');
+    const row = document.createElement('div');
+    row.className = 'invoice-item-row';
+    row.innerHTML = `
+        <label>Beschreibung
+            <input type="text" name="description" required>
+        </label>
+        <label>Menge
+            <input type="number" name="quantity" min="0" step="0.01" value="1">
+        </label>
+        <label>Einzelpreis
+            <input type="number" name="unit_price" min="0" step="0.01" value="0">
+        </label>
+        <label>Steuer %
+            <input type="number" name="tax_rate" min="0" step="0.01" value="0">
+        </label>
+        <button type="button" class="secondary remove-item">Entfernen</button>
+    `;
+    row.querySelector('.remove-item').addEventListener('click', () => {
+        row.remove();
+        if (!container.querySelector('.invoice-item-row')) {
+            addInvoiceItemRow();
+        }
+    });
+    container.appendChild(row);
+}
+
+document.getElementById('add-invoice-item').addEventListener('click', (event) => {
+    event.preventDefault();
+    addInvoiceItemRow();
+});
+
+addInvoiceItemRow();
+
+const sectionLoaders = {
+    dashboard: () => loadDashboard(true),
+    reservations: () => loadReservations(true),
+    rooms: () => loadRooms(true),
+    housekeeping: () => loadHousekeeping(true),
+    billing: () => loadBilling(true),
+    reports: () => loadReports(true),
+    users: () => loadUsers(true),
+    companies: () => loadCompanies(true),
+    guests: () => loadGuests(true),
+    integrations: () => loadIntegrations(true),
+    settings: () => loadSettings(true),
+};
+
+// Form submissions
+
+if (reservationForm) {
+    reservationForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (!requireToken()) {
+            return;
+        }
+        const adults = Number(reservationForm.adults.value || 0);
+        const children = Number(reservationForm.children.value || 0);
+        const totalGuests = adults + children;
+        if (totalGuests < 1) {
+            showMessage('Bitte mindestens einen Gast angeben.', 'error');
+            return;
+        }
+        const requests = [...state.pendingRoomRequests];
+        if (!requests.length) {
+            showMessage('Bitte mindestens eine Zimmerkategorie auswählen.', 'error');
+            return;
+        }
+        const capacity = calculateRoomRequestCapacityClient(requests);
+        if (capacity <= 0) {
+            showMessage('Für die ausgewählten Kategorien ist keine Kapazität hinterlegt.', 'error');
+            return;
+        }
+        if (totalGuests > capacity) {
+            showMessage(`Die ausgewählten Kategorien bieten nur Platz für ${capacity} Gäste.`, 'error');
+            return;
+        }
+
+        const payload = {
+            check_in_date: reservationForm.check_in.value,
+            check_out_date: reservationForm.check_out.value,
+            adults,
+            children,
+            total_amount: reservationForm.total_amount.value ? Number(reservationForm.total_amount.value) : null,
+            currency: reservationForm.currency.value || 'EUR',
+            status: reservationForm.status.value,
+            booked_via: reservationForm.booked_via.value || null,
+        };
+
+        if (requests.length) {
+            payload.room_requests = requests.map((request) => ({
+                room_type_id: Number(request.room_type_id),
+                quantity: Number(request.quantity ?? 1),
+            }));
+        }
+
+        if (reservationArticleContainer) {
+            const selections = Array.from(reservationArticleContainer.querySelectorAll('.article-option')).map((option) => {
+                const checkbox = option.querySelector('input[type="checkbox"]');
+                if (!checkbox || !checkbox.checked) {
+                    return null;
+                }
+                const articleId = Number(checkbox.value);
+                if (Number.isNaN(articleId)) {
+                    return null;
+                }
+                const multiplierInput = option.querySelector('.article-multiplier');
+                const multiplierValue = multiplierInput ? Number(multiplierInput.value || 1) : 1;
+                return {
+                    article_id: articleId,
+                    multiplier: Number.isFinite(multiplierValue) ? multiplierValue : 1,
+                };
+            }).filter(Boolean);
+            if (selections.length > 0 || isEdit) {
+                payload.articles = selections;
+            }
+        }
+
+        const selectedGuestId = guestIdInput && guestIdInput.value ? Number(guestIdInput.value) : null;
+        const guestPayload = {
+            first_name: reservationForm.guest_first.value,
+            last_name: reservationForm.guest_last.value,
+            email: reservationForm.guest_email.value || null,
+            phone: reservationForm.guest_phone.value || null,
+        };
+        if (reservationGuestCompanySelect) {
+            guestPayload.company_id = reservationGuestCompanySelect.value ? Number(reservationGuestCompanySelect.value) : null;
+        }
+
+        const isEdit = Boolean(state.editingReservationId);
+
+        if (selectedGuestId) {
+            payload.guest_id = selectedGuestId;
+            if (isEdit) {
+                payload.guest = guestPayload;
+            }
+        } else {
+            payload.guest = guestPayload;
+        }
+
+        const endpoint = isEdit ? `reservations/${state.editingReservationId}` : 'reservations';
+        const method = isEdit ? 'PUT' : 'POST';
+
+        try {
+            await apiFetch(endpoint, {
+                method,
+                body: JSON.stringify(payload),
+            });
+            showMessage(isEdit ? 'Reservierung wurde aktualisiert.' : 'Reservierung wurde angelegt.', 'success');
+            await Promise.all([
+                loadReservations(true),
+                loadDashboard(true),
+            ]);
+            resetReservationForm();
+        } catch (error) {
+            showMessage(error.message, 'error');
+        }
+    });
+}
+
+if (reservationCancelButton) {
+    reservationCancelButton.addEventListener('click', () => {
+        resetReservationForm();
+    });
+}
+
+if (roomRequestAddButton) {
+    roomRequestAddButton.addEventListener('click', () => {
+        const selectedTypeId = roomRequestTypeSelect ? Number(roomRequestTypeSelect.value) : NaN;
+        if (!Number.isFinite(selectedTypeId) || selectedTypeId <= 0) {
+            showMessage('Bitte eine Zimmerkategorie auswählen.', 'error');
+            if (roomRequestTypeSelect) {
+                roomRequestTypeSelect.focus();
+            }
+            return;
+        }
+        const quantityValue = roomRequestQuantityInput ? Number(roomRequestQuantityInput.value || 1) : 1;
+        addReservationRoomRequest(selectedTypeId, quantityValue);
+        if (roomRequestQuantityInput) {
+            roomRequestQuantityInput.value = '1';
+        }
+    });
+}
+
+if (roomRequestList) {
+    roomRequestList.addEventListener('input', (event) => {
+        const target = event.target;
+        if (!(target instanceof HTMLInputElement) || target.dataset.role !== 'room-request-quantity') {
+            return;
+        }
+        const container = target.closest('.room-request-row');
+        if (!container) {
+            return;
+        }
+        const typeId = Number(container.dataset.roomTypeId);
+        const value = Number(target.value || 1);
+        updateReservationRoomRequestQuantity(typeId, value);
+    });
+    roomRequestList.addEventListener('click', (event) => {
+        const target = event.target;
+        if (!(target instanceof HTMLButtonElement)) {
+            return;
+        }
+        if (target.dataset.action === 'remove-room-request') {
+            const container = target.closest('.room-request-row');
+            if (!container) {
+                return;
+            }
+            const typeId = Number(container.dataset.roomTypeId);
+            removeReservationRoomRequest(typeId);
+        }
+    });
+}
+
+if (reservationArticleContainer) {
+    reservationArticleContainer.addEventListener('change', (event) => {
+        const target = event.target;
+        if (!(target instanceof HTMLInputElement)) {
+            return;
+        }
+        if (target.type === 'checkbox') {
+            const option = target.closest('.article-option');
+            if (!option) {
+                return;
+            }
+            const multiplierInput = option.querySelector('.article-multiplier');
+            if (multiplierInput instanceof HTMLInputElement) {
+                multiplierInput.disabled = !target.checked;
+                if (target.checked && (!multiplierInput.value || Number(multiplierInput.value) < 0)) {
+                    multiplierInput.value = '1';
+                }
+            }
+        }
+    });
+}
+
+if (reservationForm) {
+    reservationForm.adults.addEventListener('input', updateReservationCapacityHint);
+    reservationForm.children.addEventListener('input', updateReservationCapacityHint);
+}
+
+if (guestSearchInput) {
+    guestSearchInput.addEventListener('input', () => {
+        const currentValue = guestSearchInput.value;
+        const selectedLabel = guestSearchInput.dataset.selectedLabel || '';
+        if (guestSearchInput.dataset.selectedId && currentValue !== selectedLabel) {
+            delete guestSearchInput.dataset.selectedId;
+            delete guestSearchInput.dataset.selectedLabel;
+            if (guestIdInput) {
+                guestIdInput.value = '';
+            }
+            if (guestClearSelectionButton) {
+                guestClearSelectionButton.classList.add('hidden');
+            }
+        }
+        scheduleGuestLookup(currentValue);
+    });
+
+    guestSearchInput.addEventListener('focus', () => {
+        const term = guestSearchInput.value.trim();
+        if (term.length >= 2) {
+            if (state.guestLookupResults.length === 0 || state.guestLookupTerm !== term) {
+                scheduleGuestLookup(term);
+            } else {
+                renderGuestSuggestions(state.guestLookupResults, term);
+            }
+        }
+    });
+
+    guestSearchInput.addEventListener('blur', () => {
+        setTimeout(() => {
+            hideGuestSuggestions();
+        }, 150);
+    });
+}
+
+if (guestClearSelectionButton) {
+    guestClearSelectionButton.addEventListener('click', () => {
+        clearGuestSelection();
+    });
+}
+
+if (guestSearchResults) {
+    guestSearchResults.addEventListener('mousedown', (event) => {
+        event.preventDefault();
+    });
+    guestSearchResults.addEventListener('click', (event) => {
+        const target = event.target.closest('button[data-guest-id]');
+        if (!target) {
+            return;
+        }
+        const guestId = Number(target.dataset.guestId);
+        if (!Number.isFinite(guestId)) {
+            return;
+        }
+        const guest = state.guestLookupResults.find((entry) => Number(entry.id) === guestId)
+            || state.guests.find((entry) => Number(entry.id) === guestId)
+            || null;
+        if (guest) {
+            setGuestSelection(guest);
+        } else if (guestIdInput) {
+            guestIdInput.value = String(guestId);
+        }
+        hideGuestSuggestions();
+    });
+}
+
+document.getElementById('reload-reservations').addEventListener('click', () => loadReservations(true));
+document.getElementById('reload-rooms').addEventListener('click', () => loadRooms(true));
+document.getElementById('reload-tasks').addEventListener('click', () => loadHousekeeping(true));
+document.getElementById('reload-invoices').addEventListener('click', () => loadBilling(true));
+document.getElementById('reload-payments').addEventListener('click', () => loadBilling(true));
+document.getElementById('reload-users').addEventListener('click', () => loadUsers(true));
+document.getElementById('reload-companies').addEventListener('click', () => loadCompanies(true));
+document.getElementById('reload-guests').addEventListener('click', () => loadGuests(true));
+document.getElementById('reload-integrations').addEventListener('click', () => loadIntegrations(true));
+if (settingsReloadButton) {
+    settingsReloadButton.addEventListener('click', () => loadSettings(true));
+}
+document.getElementById('refresh-dashboard').addEventListener('click', () => loadDashboard(true));
+dashboardDateInput.addEventListener('change', () => loadDashboard(true));
+document.getElementById('refresh-reports').addEventListener('click', () => loadReports(true));
+
+document.getElementById('room-form').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!requireToken()) {
+        return;
+    }
+    const form = event.target;
+    const payload = {
+        room_number: form.room_number.value,
+        room_type_id: Number(form.room_type.value),
+        floor: form.floor.value || null,
+        status: form.status.value,
+        notes: form.notes.value || null,
+    };
+    try {
+        await apiFetch('rooms', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        });
+        form.reset();
+        showMessage('Zimmer wurde gespeichert.', 'success');
+        await loadRooms(true);
+        await ensureReservationReferenceData(true);
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+});
+
+document.getElementById('room-type-form').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!requireToken()) {
+        return;
+    }
+    const form = event.target;
+    const payload = {
+        name: form.name.value,
+        base_rate: form.base_price.value ? Number(form.base_price.value) : null,
+        description: form.description.value || null,
+    };
+    try {
+        await apiFetch('room-types', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        });
+        form.reset();
+        showMessage('Zimmerkategorie erstellt.', 'success');
+        const roomTypes = await apiFetch('room-types');
+        state.roomTypes = roomTypes;
+        populateRoomTypeSelects();
+        populateRoomTypeList();
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+});
+
+document.getElementById('rate-plan-form').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!requireToken()) {
+        return;
+    }
+    const form = event.target;
+    const payload = {
+        name: form.name.value,
+        base_price: form.base_price.value ? Number(form.base_price.value) : null,
+        currency: form.currency.value || 'EUR',
+        cancellation_policy: form.cancellation_policy.value || null,
+    };
+    try {
+        await apiFetch('rate-plans', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        });
+        form.reset();
+        showMessage('Rate-Plan angelegt.', 'success');
+        const ratePlans = await apiFetch('rate-plans');
+        state.ratePlans = ratePlans;
+        populateRatePlanList();
+        await ensureReservationReferenceData(true);
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+});
+
+if (articleForm) {
+    articleForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (!requireToken()) {
+            return;
+        }
+        const form = event.target;
+        const payload = {
+            name: form.name.value,
+            description: form.description.value || null,
+            charge_scheme: form.charge_scheme.value,
+            unit_price: form.unit_price.value ? Number(form.unit_price.value) : 0,
+            tax_rate: form.tax_rate.value ? Number(form.tax_rate.value) : 0,
+            is_active: form.is_active ? form.is_active.checked : true,
+        };
+        const isEdit = Boolean(state.editingArticleId);
+        const endpoint = isEdit ? `articles/${state.editingArticleId}` : 'articles';
+        const method = isEdit ? 'PATCH' : 'POST';
+        try {
+            await apiFetch(endpoint, {
+                method,
+                body: JSON.stringify(payload),
+            });
+            showMessage(isEdit ? 'Artikel aktualisiert.' : 'Artikel angelegt.', 'success');
+            resetArticleForm();
+            await loadArticles(true);
+        } catch (error) {
+            showMessage(error.message, 'error');
+        }
+    });
+}
+
+if (articleCancelButton) {
+    articleCancelButton.addEventListener('click', () => {
+        resetArticleForm();
+    });
+}
+
+if (reloadArticlesButton) {
+    reloadArticlesButton.addEventListener('click', () => loadArticles(true));
+}
+
+if (articlesList) {
+    articlesList.addEventListener('click', async (event) => {
+        const target = event.target;
+        if (!(target instanceof HTMLElement)) {
+            return;
+        }
+        const action = target.dataset.action;
+        const id = Number(target.dataset.id);
+        if (!action || Number.isNaN(id)) {
+            return;
+        }
+        if (action === 'edit-article') {
+            startArticleEdit(id);
+            return;
+        }
+        if (!requireToken()) {
+            return;
+        }
+        try {
+            if (action === 'deactivate-article') {
+                await apiFetch(`articles/${id}`, { method: 'DELETE' });
+                showMessage('Artikel deaktiviert.', 'success');
+            } else if (action === 'activate-article') {
+                await apiFetch(`articles/${id}`, {
+                    method: 'PATCH',
+                    body: JSON.stringify({ is_active: true }),
+                });
+                showMessage('Artikel aktiviert.', 'success');
+            }
+            await loadArticles(true);
+        } catch (error) {
+            showMessage(error.message, 'error');
+        }
+    });
+}
+
+if (invoiceLogoInput) {
+    invoiceLogoInput.addEventListener('change', async () => {
+        if (!invoiceLogoInput.files || invoiceLogoInput.files.length === 0) {
+            updateInvoiceLogoPreview(state.invoiceLogoDataUrl);
+            return;
+        }
+        const file = invoiceLogoInput.files[0];
+        try {
+            const dataUrl = await readFileAsDataUrl(file);
+            updateInvoiceLogoPreview(dataUrl);
+        } catch (error) {
+            showMessage(error.message || 'Logo konnte nicht gelesen werden.', 'error');
+            updateInvoiceLogoPreview(state.invoiceLogoDataUrl);
+        }
+    });
+}
+
+if (invoiceLogoForm) {
+    invoiceLogoForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (!requireToken()) {
+            return;
+        }
+        let dataUrl = state.invoiceLogoDataUrl;
+        if (invoiceLogoInput && invoiceLogoInput.files && invoiceLogoInput.files.length > 0) {
+            try {
+                dataUrl = await readFileAsDataUrl(invoiceLogoInput.files[0]);
+            } catch (error) {
+                showMessage(error.message || 'Logo konnte nicht gelesen werden.', 'error');
+                return;
+            }
+        }
+        if (!dataUrl) {
+            showMessage('Bitte wählen Sie ein Logo aus.', 'error');
+            return;
+        }
+        try {
+            const response = await apiFetch('settings/invoice-logo', {
+                method: 'PUT',
+                body: JSON.stringify({ image: dataUrl }),
+            });
+            const logoData = response && typeof response === 'object' ? response.logo || dataUrl : dataUrl;
+            updateInvoiceLogoPreview(logoData);
+            if (invoiceLogoInput) {
+                invoiceLogoInput.value = '';
+            }
+            showMessage('Rechnungslogo gespeichert.', 'success');
+        } catch (error) {
+            showMessage(error.message, 'error');
+        }
+    });
+}
+
+if (removeInvoiceLogoButton) {
+    removeInvoiceLogoButton.addEventListener('click', async (event) => {
+        event.preventDefault();
+        if (!requireToken()) {
+            return;
+        }
+        try {
+            await apiFetch('settings/invoice-logo', { method: 'DELETE' });
+            updateInvoiceLogoPreview(null);
+            if (invoiceLogoInput) {
+                invoiceLogoInput.value = '';
+            }
+            showMessage('Rechnungslogo entfernt.', 'success');
+        } catch (error) {
+            showMessage(error.message, 'error');
+        }
+    });
+}
+
+document.getElementById('task-form').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!requireToken()) {
+        return;
+    }
+    const form = event.target;
+    const payload = {
+        room_id: form.room.value ? Number(form.room.value) : null,
+        title: form.title.value,
+        status: form.status.value,
+        due_date: toSqlDateTime(form.due_date.value),
+        description: form.description.value || null,
+    };
+    try {
+        await apiFetch('housekeeping/tasks', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        });
+        form.reset();
+        showMessage('Aufgabe gespeichert.', 'success');
+        loadHousekeeping(true);
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+});
+
+document.getElementById('invoice-form').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!requireToken()) {
+        return;
+    }
+    const form = event.target;
+    const items = Array.from(document.querySelectorAll('#invoice-items .invoice-item-row')).map((row) => {
+        const description = row.querySelector('input[name="description"]').value;
+        if (!description) {
+            return null;
+        }
+        return {
+            description,
+            quantity: Number(row.querySelector('input[name="quantity"]').value || 1),
+            unit_price: Number(row.querySelector('input[name="unit_price"]').value || 0),
+            tax_rate: Number(row.querySelector('input[name="tax_rate"]').value || 0),
+        };
+    }).filter(Boolean);
+    if (items.length === 0) {
+        showMessage('Bitte mindestens eine Rechnungsposition erfassen.', 'error');
+        return;
+    }
+    const payload = {
+        reservation_id: Number(form.reservation_id.value),
+        issue_date: form.issue_date.value || null,
+        due_date: form.due_date.value || null,
+        items,
+    };
+    try {
+        await apiFetch('invoices', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        });
+        form.reset();
+        document.getElementById('invoice-items').innerHTML = '';
+        addInvoiceItemRow();
+        showMessage('Rechnung erstellt.', 'success');
+        loadBilling(true);
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+});
+
+document.getElementById('payment-form').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!requireToken()) {
+        return;
+    }
+    const form = event.target;
+    const payload = {
+        invoice_id: Number(form.invoice_id.value),
+        method: form.method.value,
+        amount: Number(form.amount.value),
+        currency: form.currency.value || 'EUR',
+        paid_at: toSqlDateTime(form.paid_at.value),
+        reference: form.reference.value || null,
+        notes: form.notes.value || null,
+    };
+    try {
+        await apiFetch('payments', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        });
+        form.reset();
+        showMessage('Zahlung erfasst.', 'success');
+        loadBilling(true);
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+});
+
+document.getElementById('user-form').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!requireToken()) {
+        return;
+    }
+    const form = event.target;
+    const roleIds = Array.from(form.querySelectorAll('input[type="checkbox"]:checked')).map((input) => Number(input.value));
+    const payload = {
+        name: form.name.value,
+        email: form.email.value,
+        password: form.password.value,
+        role_ids: roleIds,
+    };
+    try {
+        await apiFetch('users', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        });
+        form.reset();
+        showMessage('Benutzer angelegt.', 'success');
+        loadUsers(true);
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+});
+
+document.getElementById('role-form').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!requireToken()) {
+        return;
+    }
+    const form = event.target;
+    const payload = {
+        name: form.name.value,
+        description: form.description.value || null,
+    };
+    try {
+        await apiFetch('roles', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        });
+        form.reset();
+        showMessage('Rolle erstellt.', 'success');
+        const roles = await apiFetch('roles');
+        state.roles = roles;
+        populateRoleCheckboxes();
+        renderTable('roles-list', [
+            { key: 'name', label: 'Name' },
+            { key: 'description', label: 'Beschreibung' },
+        ], roles);
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+});
+
+if (guestForm) {
+    guestForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (!requireToken()) {
+            return;
+        }
+        const payload = {
+            first_name: guestForm.first_name.value,
+            last_name: guestForm.last_name.value,
+            email: guestForm.email.value || null,
+            phone: guestForm.phone.value || null,
+            address: guestForm.address.value || null,
+            city: guestForm.city.value || null,
+            country: guestForm.country.value || null,
+            notes: guestForm.notes.value || null,
+            company_id: guestCompanySelect && guestCompanySelect.value ? Number(guestCompanySelect.value) : null,
+        };
+        const isEdit = Boolean(state.editingGuestId);
+        const endpoint = isEdit ? `guests/${state.editingGuestId}` : 'guests';
+        const method = isEdit ? 'PATCH' : 'POST';
+        try {
+            await apiFetch(endpoint, {
+                method,
+                body: JSON.stringify(payload),
+            });
+            showMessage(isEdit ? 'Gast aktualisiert.' : 'Gast gespeichert.', 'success');
+            await loadGuests(true);
+            resetGuestForm();
+        } catch (error) {
+            showMessage(error.message, 'error');
+        }
+    });
+}
+
+if (guestCancelButton) {
+    guestCancelButton.addEventListener('click', () => resetGuestForm());
+}
+
+if (guestsList) {
+    guestsList.addEventListener('click', (event) => {
+        const button = event.target.closest('.guest-edit');
+        if (!button) {
+            return;
+        }
+        const guestId = Number(button.dataset.id);
+        if (!Number.isFinite(guestId)) {
+            return;
+        }
+        startGuestEdit(guestId);
+    });
+}
+
+if (companyForm) {
+    companyForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (!requireToken()) {
+            return;
+        }
+        const payload = {
+            name: companyForm.name.value,
+            email: companyForm.email.value || null,
+            phone: companyForm.phone.value || null,
+            address: companyForm.address.value || null,
+            city: companyForm.city.value || null,
+            country: companyForm.country.value || null,
+            notes: companyForm.notes.value || null,
+        };
+        const isEdit = Boolean(state.editingCompanyId);
+        const endpoint = isEdit ? `companies/${state.editingCompanyId}` : 'companies';
+        const method = isEdit ? 'PATCH' : 'POST';
+        try {
+            await apiFetch(endpoint, {
+                method,
+                body: JSON.stringify(payload),
+            });
+            showMessage(isEdit ? 'Firma aktualisiert.' : 'Firma gespeichert.', 'success');
+            await Promise.all([
+                loadCompanies(true),
+                loadGuests(true),
+            ]);
+            resetCompanyForm();
+        } catch (error) {
+            showMessage(error.message, 'error');
+        }
+    });
+}
+
+if (companyCancelButton) {
+    companyCancelButton.addEventListener('click', () => resetCompanyForm());
+}
+
+if (companiesList) {
+    companiesList.addEventListener('click', (event) => {
+        const button = event.target.closest('.company-edit');
+        if (!button) {
+            return;
+        }
+        const companyId = Number(button.dataset.id);
+        if (!Number.isFinite(companyId)) {
+            return;
+        }
+        startCompanyEdit(companyId);
+    });
+}
+
+document.getElementById('guest-lookup').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const form = event.target;
+    const confirmation = form.confirmation.value.trim();
+    if (!confirmation) {
+        showMessage('Bitte Bestätigungsnummer eingeben.', 'error');
+        return;
+    }
+    await lookupGuestReservation(confirmation);
+});
+
+if (reservationsList) {
+    reservationsList.addEventListener('click', (event) => {
+        const statusButton = event.target.closest('.reservation-status');
+        if (statusButton) {
+            const reservationId = Number(statusButton.dataset.id);
+            const nextStatus = statusButton.dataset.status;
+            if (Number.isFinite(reservationId) && nextStatus) {
+                updateReservationStatus(reservationId, nextStatus);
+            }
+            return;
+        }
+        const button = event.target.closest('.reservation-edit');
+        if (!button) {
+            return;
+        }
+        const reservationId = Number(button.dataset.id);
+        if (!Number.isFinite(reservationId)) {
+            return;
+        }
+        startReservationEdit(reservationId);
+    });
+}
+
+if (calendarLabelSelect) {
+    calendarLabelSelect.value = state.calendarLabelMode;
+    calendarLabelSelect.addEventListener('change', () => {
+        const nextMode = calendarLabelSelect.value === 'company' ? 'company' : 'guest';
+        state.calendarLabelMode = nextMode;
+        try {
+            localStorage.setItem(CALENDAR_LABEL_KEY, nextMode);
+        } catch (error) {
+            // ignore storage failures
+        }
+        renderOccupancyCalendar(
+            state.rooms,
+            state.reservations,
+            dashboardDateInput && dashboardDateInput.value ? dashboardDateInput.value : toLocalISODate(),
+            CALENDAR_DAYS,
+            nextMode,
+        );
+    });
+}
+
+if (calendarColorForm) {
+    calendarColorForm.addEventListener('input', (event) => {
+        const input = event.target.closest('input[type="color"][data-status]');
+        if (!input) {
+            return;
+        }
+        const status = input.dataset.status;
+        const normalized = normalizeHexColorInput(input.value);
+        if (status && normalized) {
+            state.calendarColors[status] = normalized;
+            applyCalendarColors(state.calendarColors);
+        }
+    });
+
+    calendarColorForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (!requireToken()) {
+            return;
+        }
+        const payload = {};
+        CALENDAR_STATUS_ORDER.forEach((status) => {
+            const input = calendarColorForm.querySelector(`input[data-status="${status}"]`);
+            const normalized = normalizeHexColorInput(input ? input.value : null) || CALENDAR_COLOR_DEFAULTS[status];
+            payload[status] = normalized;
+        });
+        try {
+            const response = await apiFetch('settings/calendar-colors', {
+                method: 'PUT',
+                body: JSON.stringify({ colors: payload }),
+            });
+            const colors = response && typeof response.colors === 'object' ? response.colors : payload;
+            applyCalendarColors(colors);
+            populateCalendarColorInputs();
+            state.calendarColorsLoaded = true;
+            showMessage('Kalenderfarben gespeichert.', 'success');
+        } catch (error) {
+            showMessage(error.message, 'error');
+        }
+    });
+}
+
+if (resetCalendarColorsButton) {
+    resetCalendarColorsButton.addEventListener('click', async (event) => {
+        event.preventDefault();
+        if (!requireToken()) {
+            return;
+        }
+        try {
+            const response = await apiFetch('settings/calendar-colors', { method: 'DELETE' });
+            const colors = response && typeof response.colors === 'object' ? response.colors : CALENDAR_COLOR_DEFAULTS;
+            applyCalendarColors(colors);
+            populateCalendarColorInputs();
+            state.calendarColorsLoaded = true;
+            showMessage('Kalenderfarben zurückgesetzt.', 'success');
+        } catch (error) {
+            showMessage(error.message, 'error');
+        }
+    });
+}
+
+const storedToken = localStorage.getItem('realpms_api_token');
+if (storedToken) {
+    state.token = storedToken;
+    tokenInput.value = storedToken;
+    bootstrap();
+}
+
+setDefaultDates();
+showSection('dashboard');

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,654 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>realPMS Verwaltung</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<div id="notification" class="notification" role="status" aria-live="polite"></div>
+<header class="top-bar">
+    <div>
+        <h1>realPMS Prototyp</h1>
+        <p class="subtitle">Hotel-PMS Verwaltungsoberfläche</p>
+    </div>
+    <form id="token-form" class="token-form" autocomplete="off">
+        <label for="api-token">API-Token</label>
+        <input id="api-token" name="api-token" type="password" placeholder="Token eingeben" required>
+        <button type="submit">Speichern</button>
+        <button type="button" id="clear-token" class="secondary">Löschen</button>
+    </form>
+</header>
+<nav class="main-nav">
+    <button type="button" data-section="dashboard" class="active">Dashboard</button>
+    <button type="button" data-section="reservations">Reservierungen</button>
+    <button type="button" data-section="rooms">Zimmer</button>
+    <button type="button" data-section="housekeeping">Housekeeping</button>
+    <button type="button" data-section="billing">Fakturierung</button>
+    <button type="button" data-section="reports">Berichte</button>
+    <button type="button" data-section="users">Benutzer</button>
+    <button type="button" data-section="companies">Firmen</button>
+    <button type="button" data-section="guests">Gäste</button>
+    <button type="button" data-section="integrations">Integrationen</button>
+    <button type="button" data-section="settings">Einstellungen</button>
+    <button type="button" data-section="guest-portal">Gästeportal</button>
+</nav>
+<main>
+    <section id="dashboard" data-section class="active">
+        <div class="card-grid">
+            <article class="card">
+                <h2>Heutige Belegung</h2>
+                <p id="dash-occupancy-rate" class="figure">-- %</p>
+                <p id="dash-occupancy-detail" class="muted"></p>
+            </article>
+            <article class="card">
+                <h2>Monatsumsatz</h2>
+                <p id="dash-revenue-total" class="figure">-- EUR</p>
+                <p id="dash-revenue-detail" class="muted"></p>
+            </article>
+            <article class="card">
+                <h2>Offene Aufgaben</h2>
+                <p id="dash-open-tasks" class="figure">--</p>
+                <p class="muted">Housekeeping &amp; Maintenance</p>
+            </article>
+        </div>
+        <div class="panel">
+            <div class="panel-header">
+                <h3>Belegungsübersicht</h3>
+                <div class="panel-actions">
+                    <label for="dashboard-date">Datum</label>
+                    <input type="date" id="dashboard-date">
+                    <button type="button" id="refresh-dashboard" class="secondary">Aktualisieren</button>
+                    <label for="calendar-label-mode">Anzeige</label>
+                    <select id="calendar-label-mode">
+                        <option value="guest">Gastname</option>
+                        <option value="company">Firmenname</option>
+                    </select>
+                    <button type="button" id="open-calendar-settings" class="secondary">Farben anpassen</button>
+                </div>
+            </div>
+            <div class="calendar-wrapper">
+                <div id="occupancy-calendar"></div>
+            </div>
+            <div id="occupancy-table" class="table-wrapper"></div>
+        </div>
+    </section>
+
+    <section id="reservations" data-section>
+        <div class="section-header">
+            <h2>Reservierungen</h2>
+            <button type="button" id="reload-reservations" class="secondary">Neu laden</button>
+        </div>
+        <p class="table-hint">Nutzen Sie die farbigen Schnellaktionen, um Gäste mit einem Klick einzuchecken, als bezahlt zu markieren, auszuchecken oder als No-Show zu vermerken.</p>
+        <div id="reservations-list" class="table-wrapper"></div>
+        <details class="form-panel">
+            <summary>Neue Reservierung anlegen</summary>
+            <form id="reservation-form" class="grid-form">
+                <div id="reservation-meta" class="reservation-meta hidden">
+                    <div class="reservation-meta-block">
+                        <span class="meta-label">Reservierungsnummer</span>
+                        <span id="reservation-number" class="meta-value">--</span>
+                    </div>
+                    <div class="reservation-meta-block">
+                        <span class="meta-label">Rechnung</span>
+                        <div class="meta-actions">
+                            <a id="reservation-invoice-link" class="meta-link hidden" href="#" target="_blank" rel="noopener">PDF öffnen</a>
+                            <button type="button" id="reservation-create-invoice">Rechnung erstellen</button>
+                            <button type="button" id="reservation-pay-invoice" class="secondary">Als bezahlt verbuchen</button>
+                        </div>
+                        <p id="reservation-invoice-status" class="muted small-text"></p>
+                    </div>
+                </div>
+                <fieldset>
+                    <legend>Aufenthalt</legend>
+                    <label>Check-in
+                        <input type="date" name="check_in" required>
+                    </label>
+                    <label>Check-out
+                        <input type="date" name="check_out" required>
+                    </label>
+                    <label>Erwachsene
+                        <input type="number" name="adults" min="1" value="1">
+                    </label>
+                    <label>Kinder
+                        <input type="number" name="children" min="0" value="0">
+                    </label>
+                </fieldset>
+                <fieldset>
+                    <legend>Kategorien &amp; Überbuchung</legend>
+                    <p class="muted small-text">Wählen Sie vorerst nur eine Zimmerkategorie. Die konkrete Zimmerzuweisung erfolgt später.</p>
+                    <div class="room-request-controls">
+                        <label>Kategorie
+                            <select id="reservation-room-request-type"></select>
+                        </label>
+                        <label>Anzahl
+                            <input type="number" id="reservation-room-request-quantity" min="1" value="1">
+                        </label>
+                        <button type="button" id="reservation-room-request-add">Kategorie hinzufügen</button>
+                    </div>
+                    <div id="reservation-room-requests" class="room-request-list"></div>
+                    <p id="reservation-capacity" class="muted"></p>
+                </fieldset>
+                <fieldset>
+                    <legend>Gast</legend>
+                    <div class="guest-search-row">
+                        <label>Gast suchen
+                            <input type="text" name="guest_search" placeholder="Name, E-Mail oder Firma" autocomplete="off">
+                            <div id="guest-search-results" class="guest-suggestions hidden"></div>
+                        </label>
+                        <button type="button" id="guest-clear-selection" class="secondary small hidden">Auswahl löschen</button>
+                    </div>
+                    <input type="hidden" name="guest_id">
+                    <p class="muted small-text">Mindestens 2 Zeichen eingeben, um bestehende Gäste zu finden. Leerlassen für einen neuen Gast.</p>
+                    <label>Vorname
+                        <input type="text" name="guest_first" required>
+                    </label>
+                    <label>Nachname
+                        <input type="text" name="guest_last" required>
+                    </label>
+                    <label>E-Mail
+                        <input type="email" name="guest_email">
+                    </label>
+                    <label>Telefon
+                        <input type="tel" name="guest_phone">
+                    </label>
+                    <label>Firma
+                        <select name="guest_company">
+                            <option value="">Keine Firma</option>
+                        </select>
+                    </label>
+                </fieldset>
+                <fieldset>
+                    <legend>Abrechnung</legend>
+                    <label>Gesamtbetrag
+                        <input type="number" name="total_amount" min="0" step="0.01">
+                    </label>
+                    <label>Währung
+                        <input type="text" name="currency" value="EUR" maxlength="3">
+                    </label>
+                    <label>Status
+                        <select name="status">
+                            <option value="confirmed">Bestätigt</option>
+                            <option value="tentative">Voranfrage</option>
+                            <option value="checked_in">Eingecheckt</option>
+                            <option value="paid">Bezahlt</option>
+                            <option value="checked_out">Ausgecheckt</option>
+                            <option value="cancelled">Storniert</option>
+                            <option value="no_show">Nicht erschienen</option>
+                        </select>
+                    </label>
+                    <label>Quelle
+                        <input type="text" name="booked_via" placeholder="z.B. Website, Booking.com">
+                    </label>
+                    <div>
+                        <label class="inline-label">Zusatzleistungen</label>
+                        <p class="muted small-text">Wählen Sie optionale Artikel, die automatisch in die Rechnung übernommen werden.</p>
+                        <div id="reservation-article-options" class="article-grid"></div>
+                    </div>
+                </fieldset>
+                <div class="form-actions">
+                    <button type="submit">Reservierung speichern</button>
+                    <button type="button" id="reservation-cancel-edit" class="secondary hidden">Abbrechen</button>
+                </div>
+            </form>
+        </details>
+    </section>
+
+    <section id="rooms" data-section>
+        <div class="section-layout">
+            <div class="panel">
+                <div class="panel-header">
+                    <h2>Zimmer</h2>
+                    <button type="button" id="reload-rooms" class="secondary">Neu laden</button>
+                </div>
+                <div id="rooms-list" class="table-wrapper"></div>
+            </div>
+            <div class="panel">
+                <h3>Neues Zimmer</h3>
+                <form id="room-form" class="stacked-form">
+                    <label>Zimmernummer
+                        <input type="text" name="room_number" required>
+                    </label>
+                    <label>Etage
+                        <input type="text" name="floor">
+                    </label>
+                    <label>Zimmerkategorie
+                        <select name="room_type" required></select>
+                    </label>
+                    <label>Status
+                        <select name="status">
+                            <option value="available">Verfügbar</option>
+                            <option value="occupied">Belegt</option>
+                            <option value="dirty">Reinigung erforderlich</option>
+                            <option value="out_of_order">Außer Betrieb</option>
+                        </select>
+                    </label>
+                    <label>Notizen
+                        <textarea name="notes" rows="3"></textarea>
+                    </label>
+                    <button type="submit">Zimmer speichern</button>
+                </form>
+            </div>
+            <div class="panel">
+                <h3>Zimmerkategorie</h3>
+                <form id="room-type-form" class="stacked-form">
+                    <label>Name
+                        <input type="text" name="name" required>
+                    </label>
+                    <label>Grundpreis
+                        <input type="number" name="base_price" min="0" step="0.01">
+                    </label>
+                    <label>Beschreibung
+                        <textarea name="description" rows="3"></textarea>
+                    </label>
+                    <button type="submit">Kategorie anlegen</button>
+                </form>
+                <div id="room-types-list" class="table-wrapper small"></div>
+            </div>
+            <div class="panel">
+                <h3>Rate-Pläne</h3>
+                <form id="rate-plan-form" class="stacked-form">
+                    <label>Name
+                        <input type="text" name="name" required>
+                    </label>
+                    <label>Grundpreis
+                        <input type="number" name="base_price" min="0" step="0.01">
+                    </label>
+                    <label>Währung
+                        <input type="text" name="currency" value="EUR" maxlength="3">
+                    </label>
+                    <label>Stornobedingungen
+                        <textarea name="cancellation_policy" rows="2"></textarea>
+                    </label>
+                    <button type="submit">Rate-Plan erstellen</button>
+                </form>
+                <div id="rate-plans-list" class="table-wrapper small"></div>
+            </div>
+        </div>
+    </section>
+
+    <section id="housekeeping" data-section>
+        <div class="section-header">
+            <h2>Housekeeping &amp; Maintenance</h2>
+            <button type="button" id="reload-tasks" class="secondary">Neu laden</button>
+        </div>
+        <div id="tasks-list" class="table-wrapper"></div>
+        <details class="form-panel">
+            <summary>Neue Aufgabe</summary>
+            <form id="task-form" class="grid-form">
+                <label>Zimmer
+                    <select name="room"></select>
+                </label>
+                <label>Titel
+                    <input type="text" name="title" required>
+                </label>
+                <label>Status
+                    <select name="status">
+                        <option value="open">Offen</option>
+                        <option value="in_progress">In Bearbeitung</option>
+                        <option value="done">Erledigt</option>
+                    </select>
+                </label>
+                <label>Fällig am
+                    <input type="datetime-local" name="due_date">
+                </label>
+                <label>Beschreibung
+                    <textarea name="description" rows="3"></textarea>
+                </label>
+                <button type="submit">Aufgabe speichern</button>
+            </form>
+        </details>
+    </section>
+
+    <section id="billing" data-section>
+        <div class="section-layout">
+            <div class="panel">
+                <div class="panel-header">
+                    <h2>Rechnungen</h2>
+                    <button type="button" id="reload-invoices" class="secondary">Neu laden</button>
+                </div>
+                <div id="invoices-list" class="table-wrapper"></div>
+            </div>
+            <div class="panel">
+                <h3>Neue Rechnung</h3>
+                <form id="invoice-form" class="stacked-form">
+                    <label>Reservierung
+                        <input type="number" name="reservation_id" min="1" required>
+                    </label>
+                    <label>Ausstellungsdatum
+                        <input type="date" name="issue_date">
+                    </label>
+                    <label>Fälligkeitsdatum
+                        <input type="date" name="due_date">
+                    </label>
+                    <div id="invoice-items" class="invoice-items"></div>
+                    <button type="button" id="add-invoice-item" class="secondary">Position hinzufügen</button>
+                    <button type="submit">Rechnung erstellen</button>
+                </form>
+            </div>
+            <div class="panel">
+                <div class="panel-header">
+                    <h3>Artikel &amp; Zusatzleistungen</h3>
+                    <button type="button" id="reload-articles" class="secondary">Neu laden</button>
+                </div>
+                <div id="articles-list" class="table-wrapper"></div>
+                <form id="article-form" class="grid-form">
+                    <h4>Neuer Artikel</h4>
+                    <label>Name
+                        <input type="text" name="name" required>
+                    </label>
+                    <label>Beschreibung
+                        <textarea name="description" rows="2"></textarea>
+                    </label>
+                    <label>Abrechnungsart
+                        <select name="charge_scheme">
+                            <option value="per_person_per_day">pro Person &amp; Tag</option>
+                            <option value="per_room_per_day">pro Zimmer &amp; Tag</option>
+                            <option value="per_stay">pro Aufenthalt</option>
+                            <option value="per_person">pro Person</option>
+                            <option value="per_day">pro Tag</option>
+                        </select>
+                    </label>
+                    <label>Einzelpreis (netto)
+                        <input type="number" name="unit_price" min="0" step="0.01" value="0.00">
+                    </label>
+                    <label>Mehrwertsteuer %
+                        <input type="number" name="tax_rate" min="0" step="0.1" value="19.0">
+                    </label>
+                    <label class="checkbox-inline">
+                        <input type="checkbox" name="is_active" checked>
+                        Aktiv
+                    </label>
+                    <div class="form-actions">
+                        <button type="submit">Artikel speichern</button>
+                        <button type="button" id="article-cancel-edit" class="secondary hidden">Abbrechen</button>
+                    </div>
+                </form>
+            </div>
+            <div class="panel">
+                <div class="panel-header">
+                    <h2>Zahlungen</h2>
+                    <button type="button" id="reload-payments" class="secondary">Neu laden</button>
+                </div>
+                <div id="payments-list" class="table-wrapper"></div>
+                <form id="payment-form" class="stacked-form">
+                    <h3>Neue Zahlung</h3>
+                    <label>Rechnung
+                        <input type="number" name="invoice_id" min="1" required>
+                    </label>
+                    <label>Methode
+                        <input type="text" name="method" placeholder="z.B. Bar, EC" required>
+                    </label>
+                    <label>Betrag
+                        <input type="number" name="amount" min="0" step="0.01" required>
+                    </label>
+                    <label>Währung
+                        <input type="text" name="currency" value="EUR" maxlength="3">
+                    </label>
+                    <label>Bezahlt am
+                        <input type="datetime-local" name="paid_at">
+                    </label>
+                    <label>Referenz
+                        <input type="text" name="reference">
+                    </label>
+                    <label>Notizen
+                        <textarea name="notes" rows="2"></textarea>
+                    </label>
+                    <button type="submit">Zahlung erfassen</button>
+                </form>
+            </div>
+        </div>
+    </section>
+
+    <section id="reports" data-section>
+        <div class="panel">
+            <div class="panel-header">
+                <h2>Berichte</h2>
+                <div class="panel-actions">
+                    <label>Von
+                        <input type="date" id="report-start">
+                    </label>
+                    <label>Bis
+                        <input type="date" id="report-end">
+                    </label>
+                    <button type="button" id="refresh-reports" class="secondary">Aktualisieren</button>
+                </div>
+            </div>
+            <div class="report-grid">
+                <div>
+                    <h3>Belegung</h3>
+                    <div id="report-occupancy" class="table-wrapper"></div>
+                </div>
+                <div>
+                    <h3>Umsatz</h3>
+                    <div id="report-revenue" class="table-wrapper"></div>
+                </div>
+                <div>
+                    <h3>Forecast</h3>
+                    <div id="report-forecast" class="table-wrapper"></div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="users" data-section>
+        <div class="section-layout">
+            <div class="panel">
+                <div class="panel-header">
+                    <h2>Benutzer</h2>
+                    <button type="button" id="reload-users" class="secondary">Neu laden</button>
+                </div>
+                <div id="users-list" class="table-wrapper"></div>
+            </div>
+            <div class="panel">
+                <h3>Benutzer anlegen</h3>
+                <form id="user-form" class="stacked-form">
+                    <label>Name
+                        <input type="text" name="name" required>
+                    </label>
+                    <label>E-Mail
+                        <input type="email" name="email" required>
+                    </label>
+                    <label>Passwort
+                        <input type="password" name="password" required>
+                    </label>
+                    <fieldset>
+                        <legend>Rollen</legend>
+                        <div id="user-roles" class="checkbox-grid"></div>
+                    </fieldset>
+                    <button type="submit">Benutzer speichern</button>
+                </form>
+            </div>
+            <div class="panel">
+                <h3>Rollenverwaltung</h3>
+                <form id="role-form" class="stacked-form">
+                    <label>Name
+                        <input type="text" name="name" required>
+                    </label>
+                    <label>Beschreibung
+                        <textarea name="description" rows="2"></textarea>
+                    </label>
+                    <button type="submit">Rolle erstellen</button>
+                </form>
+                <div id="roles-list" class="table-wrapper small"></div>
+            </div>
+        </div>
+    </section>
+
+    <section id="companies" data-section>
+        <div class="section-header">
+            <h2>Firmen</h2>
+            <button type="button" id="reload-companies" class="secondary">Neu laden</button>
+        </div>
+        <div id="companies-list" class="table-wrapper"></div>
+        <details class="form-panel">
+            <summary>Firma anlegen</summary>
+            <form id="company-form" class="grid-form">
+                <label>Firmenname
+                    <input type="text" name="name" required>
+                </label>
+                <label>E-Mail
+                    <input type="email" name="email">
+                </label>
+                <label>Telefon
+                    <input type="tel" name="phone">
+                </label>
+                <label>Adresse
+                    <input type="text" name="address">
+                </label>
+                <label>Stadt
+                    <input type="text" name="city">
+                </label>
+                <label>Land
+                    <input type="text" name="country">
+                </label>
+                <label>Notizen
+                    <textarea name="notes" rows="3"></textarea>
+                </label>
+                <div class="form-actions">
+                    <button type="submit">Firma speichern</button>
+                    <button type="button" id="company-cancel-edit" class="secondary hidden">Abbrechen</button>
+                </div>
+            </form>
+        </details>
+    </section>
+
+    <section id="guests" data-section>
+        <div class="section-header">
+            <h2>Gäste</h2>
+            <button type="button" id="reload-guests" class="secondary">Neu laden</button>
+        </div>
+        <div id="guests-list" class="table-wrapper"></div>
+        <details class="form-panel">
+            <summary>Gast anlegen</summary>
+            <form id="guest-form" class="grid-form">
+                <label>Vorname
+                    <input type="text" name="first_name" required>
+                </label>
+                <label>Nachname
+                    <input type="text" name="last_name" required>
+                </label>
+                <label>E-Mail
+                    <input type="email" name="email">
+                </label>
+                <label>Telefon
+                    <input type="tel" name="phone">
+                </label>
+                <label>Adresse
+                    <input type="text" name="address">
+                </label>
+                <label>Stadt
+                    <input type="text" name="city">
+                </label>
+                <label>Land
+                    <input type="text" name="country">
+                </label>
+                <label>Firma
+                    <select name="company_id">
+                        <option value="">Keine Firma</option>
+                    </select>
+                </label>
+                <label>Notizen
+                    <textarea name="notes" rows="3"></textarea>
+                </label>
+                <div class="form-actions">
+                    <button type="submit">Gast speichern</button>
+                    <button type="button" id="guest-cancel-edit" class="secondary hidden">Abbrechen</button>
+                </div>
+            </form>
+        </details>
+    </section>
+
+    <section id="integrations" data-section>
+        <div class="panel">
+            <div class="panel-header">
+                <h2>Integrationsstatus</h2>
+                <button type="button" id="reload-integrations" class="secondary">Neu laden</button>
+            </div>
+            <div id="integrations-list" class="integration-grid"></div>
+        </div>
+    </section>
+
+    <section id="settings" data-section>
+        <div class="section-header">
+            <h2>Einstellungen</h2>
+            <button type="button" id="reload-settings" class="secondary">Neu laden</button>
+        </div>
+        <div class="panel">
+            <h3>Kalenderfarben</h3>
+            <p class="muted">Wählen Sie die Farben für die Reservierungsstatus im Dashboard-Kalender und in den Schnellaktionen.</p>
+            <form id="calendar-color-form" class="stacked-form">
+                <div class="color-grid">
+                    <label>
+                        <span>Voranfrage</span>
+                        <input type="color" data-status="tentative" value="#f97316">
+                    </label>
+                    <label>
+                        <span>Bestätigt</span>
+                        <input type="color" data-status="confirmed" value="#2563eb">
+                    </label>
+                    <label>
+                        <span>Angereist</span>
+                        <input type="color" data-status="checked_in" value="#16a34a">
+                    </label>
+                    <label>
+                        <span>Bezahlt</span>
+                        <input type="color" data-status="paid" value="#0ea5e9">
+                    </label>
+                    <label>
+                        <span>Abgereist</span>
+                        <input type="color" data-status="checked_out" value="#6b7280">
+                    </label>
+                    <label>
+                        <span>Storniert</span>
+                        <input type="color" data-status="cancelled" value="#ef4444">
+                    </label>
+                    <label>
+                        <span>No-Show</span>
+                        <input type="color" data-status="no_show" value="#7c3aed">
+                    </label>
+                </div>
+                <div class="form-actions">
+                    <button type="submit">Speichern</button>
+                    <button type="button" id="reset-calendar-colors" class="secondary">Zurücksetzen</button>
+                </div>
+            </form>
+        </div>
+        <div class="panel">
+            <h3>Rechnungslogo</h3>
+            <p class="muted">Laden Sie ein PNG- oder JPEG-Logo hoch. Es erscheint automatisch auf PDF-Rechnungen.</p>
+            <form id="invoice-logo-form" class="stacked-form" enctype="multipart/form-data">
+                <label>Logo auswählen
+                    <input type="file" accept="image/png,image/jpeg">
+                </label>
+                <div id="invoice-logo-preview" class="logo-preview">
+                    <p class="muted">Noch kein Logo hochgeladen.</p>
+                </div>
+                <div class="form-actions">
+                    <button type="submit">Logo speichern</button>
+                    <button type="button" id="remove-invoice-logo" class="secondary hidden">Logo entfernen</button>
+                </div>
+            </form>
+        </div>
+    </section>
+
+    <section id="guest-portal" data-section>
+        <div class="panel">
+            <h2>Gästeportal Vorschau</h2>
+            <form id="guest-lookup" class="inline-form">
+                <label>Bestätigungsnummer
+                    <input type="text" name="confirmation" required>
+                </label>
+                <button type="submit">Reservierung anzeigen</button>
+            </form>
+            <div id="guest-portal-result" class="table-wrapper"></div>
+        </div>
+    </section>
+</main>
+<footer class="app-footer">
+    <p>realPMS Prototype &mdash; Demonstrationsoberfläche</p>
+</footer>
+<script src="app.js" type="module"></script>
+</body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,996 @@
+:root {
+    color-scheme: light dark;
+    --bg: #f6f7fb;
+    --surface: #ffffff;
+    --surface-alt: #f0f2f9;
+    --primary: #2563eb;
+    --primary-dark: #1d4ed8;
+    --text: #1f2937;
+    --muted: #6b7280;
+    --border: #d1d5db;
+    --calendar-color-tentative: #f97316;
+    --calendar-border-tentative: rgba(249, 115, 22, 0.55);
+    --calendar-text-tentative: #ffffff;
+    --calendar-color-confirmed: #2563eb;
+    --calendar-border-confirmed: rgba(37, 99, 235, 0.55);
+    --calendar-text-confirmed: #ffffff;
+    --calendar-color-checked_in: #16a34a;
+    --calendar-border-checked_in: rgba(22, 163, 74, 0.55);
+    --calendar-text-checked_in: #ffffff;
+    --calendar-color-paid: #0ea5e9;
+    --calendar-border-paid: rgba(14, 165, 233, 0.55);
+    --calendar-text-paid: #ffffff;
+    --calendar-color-checked_out: #6b7280;
+    --calendar-border-checked_out: rgba(107, 114, 128, 0.55);
+    --calendar-text-checked_out: #ffffff;
+    --calendar-color-cancelled: #ef4444;
+    --calendar-border-cancelled: rgba(239, 68, 68, 0.55);
+    --calendar-text-cancelled: #ffffff;
+    --calendar-color-no_show: #7c3aed;
+    --calendar-border-no_show: rgba(124, 58, 237, 0.55);
+    --calendar-text-no_show: #ffffff;
+    font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+}
+
+body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.hidden {
+    display: none !important;
+}
+
+.top-bar {
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    padding: 1rem 2rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 2rem;
+}
+
+.subtitle {
+    margin: 0;
+    color: var(--muted);
+}
+
+.token-form {
+    display: flex;
+    gap: .75rem;
+    align-items: center;
+}
+
+.token-form input {
+    padding: .5rem .75rem;
+    border-radius: .5rem;
+    border: 1px solid var(--border);
+    min-width: 14rem;
+}
+
+button {
+    cursor: pointer;
+    border: none;
+    border-radius: .5rem;
+    padding: .6rem 1.1rem;
+    background: var(--primary);
+    color: white;
+    font-weight: 600;
+    transition: background .2s ease-in-out;
+}
+
+button.secondary {
+    background: var(--surface-alt);
+    color: var(--text);
+    border: 1px solid var(--border);
+}
+
+button:hover {
+    background: var(--primary-dark);
+}
+
+button.secondary:hover {
+    background: var(--border);
+}
+
+button.small {
+    font-size: .85rem;
+    padding: .35rem .75rem;
+}
+
+.main-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .75rem;
+    padding: 1rem 2rem;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+}
+
+.main-nav button {
+    background: transparent;
+    color: var(--muted);
+    border: none;
+    padding: .35rem 0;
+    position: relative;
+}
+
+.main-nav button::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: -.75rem;
+    width: 100%;
+    height: 3px;
+    background: transparent;
+    border-radius: 999px;
+    transition: background .2s ease-in-out;
+}
+
+.main-nav button.active {
+    color: var(--primary);
+    font-weight: 600;
+}
+
+.main-nav button.active::after {
+    background: var(--primary);
+}
+
+main {
+    flex: 1;
+    padding: 2rem;
+    display: grid;
+}
+
+section[data-section] {
+    display: none;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+section[data-section].active {
+    display: flex;
+}
+
+.card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+}
+
+.card {
+    background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
+    color: #ffffff;
+    border-radius: 1rem;
+    padding: 1.5rem;
+    box-shadow: 0 10px 25px rgba(37, 99, 235, 0.2);
+}
+
+.card .figure {
+    font-size: 2.2rem;
+    margin: .5rem 0;
+}
+
+.card .muted {
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.panel {
+    background: var(--surface);
+    border-radius: 1rem;
+    box-shadow: 0 10px 25px rgba(15, 23, 42, 0.05);
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.panel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.panel-actions {
+    display: flex;
+    gap: .75rem;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+.section-layout {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+}
+
+.table-wrapper {
+    overflow-x: auto;
+    background: var(--surface);
+    border-radius: 1rem;
+    box-shadow: 0 10px 25px rgba(15, 23, 42, 0.05);
+    padding: 1rem 1.25rem;
+    margin-bottom: 1.5rem;
+}
+
+.panel .table-wrapper {
+    background: transparent;
+    box-shadow: none;
+    padding: 0;
+    margin-bottom: 0;
+    margin-top: 1rem;
+}
+
+.data-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 520px;
+}
+
+.data-table thead th {
+    font-size: .75rem;
+    text-transform: uppercase;
+    letter-spacing: .05em;
+    color: var(--muted);
+    background: var(--surface-alt);
+}
+
+.data-table th,
+.data-table td {
+    text-align: left;
+    padding: .75rem 1rem;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+    word-break: break-word;
+}
+
+.data-table tbody tr:hover {
+    background: var(--surface-alt);
+}
+
+.table-subline {
+    display: block;
+    font-size: .75rem;
+    color: var(--muted);
+    margin-top: .25rem;
+}
+
+.table-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .5rem;
+    align-items: center;
+}
+
+.table-hint {
+    margin: 0 0 1rem;
+    color: var(--muted);
+}
+
+button.status-action {
+    background: var(--action-color, var(--primary));
+    border: 1px solid var(--action-border, transparent);
+    color: var(--action-text, #ffffff);
+    padding: .4rem .75rem;
+    border-radius: 999px;
+    font-size: .75rem;
+    line-height: 1;
+    font-weight: 600;
+}
+
+button.status-action:hover {
+    background: var(--action-color, var(--primary));
+    filter: brightness(0.92);
+}
+
+button.status-action:disabled,
+button.status-action:disabled:hover {
+    opacity: .6;
+    cursor: default;
+    filter: none;
+}
+
+.table-actions .reservation-edit {
+    padding: .45rem .9rem;
+}
+
+.calendar-wrapper {
+    overflow-x: auto;
+}
+
+.calendar-table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+    min-width: 720px;
+    font-size: .85rem;
+    background: var(--surface);
+}
+
+.calendar-table thead th {
+    position: sticky;
+    top: 0;
+    background: var(--surface);
+    z-index: 2;
+}
+
+.calendar-table th,
+.calendar-table td {
+    border: 1px solid var(--border);
+    padding: .55rem .6rem;
+    text-align: center;
+    white-space: nowrap;
+}
+
+.calendar-table th.room,
+.calendar-table td.room {
+    text-align: left;
+    position: sticky;
+    left: 0;
+    background: var(--surface);
+    min-width: 140px;
+    z-index: 3;
+}
+
+.calendar-table tbody th.room {
+    font-weight: 600;
+}
+
+.calendar-table td.vacant {
+    background: var(--surface-alt);
+    color: var(--muted);
+}
+
+.calendar-table td.occupied {
+    background: var(--calendar-color-confirmed);
+    color: var(--calendar-text-confirmed);
+    font-weight: 600;
+    border-color: var(--calendar-border-confirmed);
+    cursor: pointer;
+}
+
+.calendar-table td.occupied.status-tentative {
+    background: var(--calendar-color-tentative);
+    color: var(--calendar-text-tentative);
+    border-color: var(--calendar-border-tentative);
+}
+
+.calendar-table td.occupied.status-confirmed {
+    background: var(--calendar-color-confirmed);
+    color: var(--calendar-text-confirmed);
+    border-color: var(--calendar-border-confirmed);
+}
+
+.calendar-table td.occupied.status-checked_in {
+    background: var(--calendar-color-checked_in);
+    color: var(--calendar-text-checked_in);
+    border-color: var(--calendar-border-checked_in);
+}
+
+.calendar-table td.occupied.status-paid {
+    background: var(--calendar-color-paid);
+    color: var(--calendar-text-paid);
+    border-color: var(--calendar-border-paid);
+}
+
+.calendar-table td.occupied.status-checked_out {
+    background: var(--calendar-color-checked_out);
+    color: var(--calendar-text-checked_out);
+    border-color: var(--calendar-border-checked_out);
+}
+
+.calendar-table td.occupied.status-cancelled {
+    background: var(--calendar-color-cancelled);
+    color: var(--calendar-text-cancelled);
+    border-color: var(--calendar-border-cancelled);
+}
+
+.calendar-table td.occupied.status-no_show {
+    background: var(--calendar-color-no_show);
+    color: var(--calendar-text-no_show);
+    border-color: var(--calendar-border-no_show);
+    background-image: repeating-linear-gradient(135deg, rgba(255, 255, 255, 0.28) 0 12px, transparent 12px 24px);
+}
+
+.calendar-table td.occupied.multi {
+    background: var(--surface);
+    color: inherit;
+    border-color: rgba(15, 23, 42, 0.1);
+}
+
+.calendar-entry {
+    display: block;
+    padding: 4px 6px;
+    margin: 2px 0;
+    border-radius: 6px;
+    background: rgba(15, 23, 42, 0.08);
+    color: inherit;
+    font-weight: 600;
+    cursor: pointer;
+    border: 1px solid transparent;
+}
+
+.calendar-entry + .calendar-entry {
+    margin-top: 4px;
+}
+
+.calendar-entry.status-tentative {
+    background: var(--calendar-color-tentative);
+    color: var(--calendar-text-tentative);
+    border-color: var(--calendar-border-tentative);
+}
+
+.calendar-entry.status-confirmed {
+    background: var(--calendar-color-confirmed);
+    color: var(--calendar-text-confirmed);
+    border-color: var(--calendar-border-confirmed);
+}
+
+.calendar-entry.status-checked_in {
+    background: var(--calendar-color-checked_in);
+    color: var(--calendar-text-checked_in);
+    border-color: var(--calendar-border-checked_in);
+}
+
+.calendar-entry.status-paid {
+    background: var(--calendar-color-paid);
+    color: var(--calendar-text-paid);
+    border-color: var(--calendar-border-paid);
+}
+
+.calendar-entry.status-checked_out {
+    background: var(--calendar-color-checked_out);
+    color: var(--calendar-text-checked_out);
+    border-color: var(--calendar-border-checked_out);
+}
+
+.calendar-entry.status-cancelled {
+    background: var(--calendar-color-cancelled);
+    color: var(--calendar-text-cancelled);
+    border-color: var(--calendar-border-cancelled);
+}
+
+.calendar-entry.status-no_show {
+    background: var(--calendar-color-no_show);
+    color: var(--calendar-text-no_show);
+    border-color: var(--calendar-border-no_show);
+    background-image: repeating-linear-gradient(135deg, rgba(255, 255, 255, 0.28) 0 12px, transparent 12px 24px);
+}
+
+.calendar-entry.overbooking {
+    opacity: 0.95;
+}
+
+.overbooking-row th.room {
+    background: rgba(15, 23, 42, 0.06);
+    font-weight: 600;
+}
+
+.calendar-table th.today,
+.calendar-table td.today {
+    box-shadow: inset 0 0 0 2px rgba(37, 99, 235, 0.35);
+}
+
+.calendar-table td.occupied.today {
+    box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.65);
+}
+
+.calendar-table th.weekend {
+    background: rgba(15, 23, 42, 0.04);
+}
+
+.calendar-table td.weekend:not(.occupied) {
+    background: rgba(15, 23, 42, 0.04);
+}
+
+.calendar-table td.weekend.vacant {
+    color: var(--muted);
+}
+
+.form-panel {
+    background: var(--surface);
+    border-radius: 1rem;
+    box-shadow: 0 10px 25px rgba(15, 23, 42, 0.05);
+    padding: 1rem 1.5rem;
+}
+
+.form-panel summary {
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.grid-form {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem 1.5rem;
+}
+
+.reservation-meta {
+    grid-column: 1 / -1;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    padding: .75rem 1rem;
+    border: 1px dashed var(--border);
+    border-radius: .75rem;
+    background: var(--surface-alt);
+    align-items: flex-start;
+}
+
+.reservation-meta-block {
+    display: flex;
+    flex-direction: column;
+    gap: .4rem;
+    min-width: 220px;
+}
+
+.meta-label {
+    font-size: .75rem;
+    font-weight: 600;
+    letter-spacing: .05em;
+    text-transform: uppercase;
+    color: var(--muted);
+}
+
+.meta-value {
+    font-size: 1.1rem;
+    font-weight: 700;
+}
+
+.meta-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .5rem;
+    align-items: center;
+}
+
+.meta-link {
+    color: var(--primary);
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.meta-link:hover {
+    text-decoration: underline;
+}
+
+.color-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.color-grid label {
+    display: flex;
+    flex-direction: column;
+    gap: .35rem;
+    font-weight: 600;
+}
+
+.color-grid span {
+    font-size: .85rem;
+    color: var(--muted);
+}
+
+.color-grid input[type="color"] {
+    width: 100%;
+    height: 2.75rem;
+    border-radius: .75rem;
+    border: 1px solid var(--border);
+    padding: 0;
+    cursor: pointer;
+    background: transparent;
+}
+
+.grid-form fieldset {
+    border: 1px solid var(--border);
+    border-radius: .75rem;
+    padding: 1rem;
+    display: grid;
+    gap: .75rem;
+}
+
+.grid-form legend {
+    font-weight: 600;
+    padding: 0 .35rem;
+}
+
+.grid-form label,
+.stacked-form label {
+    display: flex;
+    flex-direction: column;
+    gap: .4rem;
+    font-size: .95rem;
+}
+
+.grid-form h4 {
+    grid-column: 1 / -1;
+    margin: 0;
+}
+
+.inline-label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: .35rem;
+}
+
+.small-text {
+    font-size: .85rem;
+    color: var(--muted);
+}
+
+.checkbox-inline {
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+    font-weight: 600;
+}
+
+.article-grid {
+    display: flex;
+    flex-direction: column;
+    gap: .75rem;
+    margin-top: .5rem;
+}
+
+.article-option {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: .9rem 1rem;
+    border: 1px solid var(--border);
+    border-radius: .75rem;
+    background: var(--surface-alt);
+}
+
+.article-option label {
+    display: flex;
+    align-items: flex-start;
+    gap: .75rem;
+    flex: 1;
+    margin: 0;
+}
+
+.article-option span {
+    display: flex;
+    flex-direction: column;
+    gap: .25rem;
+}
+
+.article-option small {
+    color: var(--muted);
+}
+
+.article-option em {
+    font-style: normal;
+    color: var(--muted);
+    font-size: .85rem;
+}
+
+.room-request-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: flex-end;
+    margin-bottom: 0.75rem;
+}
+
+.room-request-controls label {
+    flex: 1 1 220px;
+}
+
+.room-request-controls button {
+    margin-top: 0.5rem;
+}
+
+.room-request-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.room-request-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.75rem 1rem;
+    border: 1px solid rgba(15, 23, 42, 0.12);
+    border-radius: 8px;
+    background: rgba(15, 23, 42, 0.03);
+}
+
+.room-request-info {
+    flex: 1 1 auto;
+}
+
+.room-request-info strong {
+    display: block;
+    margin-bottom: 0.25rem;
+}
+
+.room-request-meta {
+    font-size: 0.85rem;
+    color: var(--muted);
+}
+
+.room-request-actions {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.5rem;
+}
+
+.room-request-actions .inline-label {
+    display: flex;
+    flex-direction: column;
+    font-weight: 600;
+    gap: 0.25rem;
+}
+
+.room-request-actions input[type="number"] {
+    width: 90px;
+}
+
+.article-option input[type="checkbox"] {
+    margin-top: .25rem;
+}
+
+.article-option .article-multiplier {
+    width: 5.5rem;
+    text-align: right;
+}
+
+.guest-search-row {
+    display: flex;
+    align-items: flex-end;
+    gap: .75rem;
+    position: relative;
+}
+
+.guest-search-row label {
+    flex: 1 1 auto;
+    position: relative;
+}
+
+.guest-search-row input[name="guest_search"] {
+    width: 100%;
+}
+
+.guest-suggestions {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: calc(100% + .25rem);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: .75rem;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.12);
+    max-height: 16rem;
+    overflow-y: auto;
+    padding: .25rem 0;
+    z-index: 40;
+}
+
+.guest-suggestions.hidden {
+    display: none;
+}
+
+.guest-suggestion {
+    width: 100%;
+    text-align: left;
+    background: none;
+    border: none;
+    padding: .6rem 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: .25rem;
+    cursor: pointer;
+    font-size: .95rem;
+}
+
+.guest-suggestion:hover,
+.guest-suggestion:focus {
+    background: var(--surface-alt);
+}
+
+.guest-suggestion-name {
+    font-weight: 600;
+    color: var(--text);
+}
+
+.guest-suggestion-meta {
+    font-size: .85rem;
+    color: var(--muted);
+}
+
+.text-link {
+    background: none;
+    border: none;
+    color: var(--primary);
+    padding: 0;
+    font: inherit;
+    cursor: pointer;
+    text-decoration: underline;
+}
+
+.text-link:hover {
+    color: var(--primary-dark);
+}
+
+.logo-preview {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 160px;
+    border: 2px dashed var(--border);
+    border-radius: .75rem;
+    background: var(--surface-alt);
+    padding: 1rem;
+    text-align: center;
+}
+
+.logo-image {
+    max-width: 320px;
+    width: 100%;
+    height: auto;
+    object-fit: contain;
+}
+
+input, select, textarea {
+    border: 1px solid var(--border);
+    border-radius: .5rem;
+    padding: .55rem .7rem;
+    font: inherit;
+    background: #fff;
+}
+
+textarea {
+    resize: vertical;
+}
+
+.form-actions {
+    grid-column: 1 / -1;
+    display: flex;
+    justify-content: flex-end;
+}
+
+.stacked-form {
+    display: grid;
+    gap: 1rem;
+}
+
+.checkbox-grid {
+    display: grid;
+    gap: .5rem;
+}
+
+.checkbox-grid label {
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+    font-weight: 500;
+}
+
+.invoice-items {
+    display: grid;
+    gap: .75rem;
+}
+
+.invoice-item-row {
+    display: grid;
+    grid-template-columns: 1.5fr repeat(3, minmax(80px, 1fr));
+    gap: .5rem;
+    align-items: end;
+}
+
+.invoice-item-row label {
+    display: flex;
+    flex-direction: column;
+    gap: .25rem;
+    font-size: .9rem;
+}
+
+.inline-form {
+    display: flex;
+    gap: 1rem;
+    align-items: flex-end;
+    flex-wrap: wrap;
+}
+
+.integration-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+}
+
+.integration-card {
+    border: 1px solid var(--border);
+    border-radius: .75rem;
+    padding: 1rem;
+    background: var(--surface-alt);
+}
+
+.notification {
+    position: fixed;
+    top: 1rem;
+    right: 1rem;
+    padding: 1rem 1.25rem;
+    border-radius: .75rem;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    box-shadow: 0 10px 25px rgba(15, 23, 42, 0.15);
+    min-width: 220px;
+    z-index: 1000;
+    display: none;
+}
+
+.notification.show {
+    display: block;
+}
+
+.notification.success {
+    border-color: #16a34a;
+    color: #166534;
+}
+
+.notification.error {
+    border-color: #dc2626;
+    color: #991b1b;
+}
+
+.notification.info {
+    border-color: var(--primary);
+    color: var(--primary-dark);
+}
+
+.report-grid {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.muted {
+    color: var(--muted);
+}
+
+.text-danger {
+    color: #b91c1c;
+    font-weight: 600;
+}
+
+.app-footer {
+    padding: 1rem 2rem;
+    text-align: center;
+    color: var(--muted);
+}
+
+@media (max-width: 720px) {
+    .top-bar {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .token-form {
+        width: 100%;
+        flex-wrap: wrap;
+    }
+
+    .invoice-item-row {
+        grid-template-columns: 1fr;
+    }
+}


### PR DESCRIPTION
## Summary
- stop trying to hydrate a non-existent reservation rate-plan select and trim the unused helper
- ensure reservation reference refreshes only touches the active room/category selectors after data loads
- keep the rate-plan admin flow updating its table without re-invoking the removed helper

## Testing
- node --check public/app.js

------
https://chatgpt.com/codex/tasks/task_e_68ef7477204c833396f1c87cd8c9239d