### PR TITLE
Update room type occupancy management

### DIFF
--- a/install.php
+++ b/install.php
@@ -369,7 +369,6 @@ function getSchemaStatements(): array
                 description TEXT NULL,
                 base_occupancy TINYINT UNSIGNED NOT NULL DEFAULT 1,
                 max_occupancy TINYINT UNSIGNED NOT NULL DEFAULT 1,
-                base_rate DECIMAL(10,2) NULL,
                 currency CHAR(3) NULL,
                 created_at TIMESTAMP NULL,
                 updated_at TIMESTAMP NULL

--- a/public/index.html
+++ b/public/index.html
@@ -236,9 +236,13 @@
                     <label>Name
                         <input type="text" name="name" required>
                     </label>
-                    <label>Grundpreis
-                        <input type="number" name="base_price" min="0" step="0.01">
+                    <label>Basisbelegung
+                        <input type="number" name="base_occupancy" min="1" step="1" value="1" required>
                     </label>
+                    <label>Maximalbelegung
+                        <input type="number" name="max_occupancy" min="1" step="1" value="1" required>
+                    </label>
+                    <p class="muted small-text">Geben Sie an, wie viele Gäste standardmäßig bzw. maximal in dieser Kategorie untergebracht werden können.</p>
                     <label>Beschreibung
                         <textarea name="description" rows="3"></textarea>
                     </label>


### PR DESCRIPTION
## Summary
- replace the room type UI field for base price with base and maximum occupancy inputs and hints
- update the frontend logic to validate and submit occupancy values while displaying capacities in the room type list
- adjust the API, schema defaults, and nightly rate fallback to drop base rate usage and require explicit occupancy data

## Testing
- php -l backend/api/index.php

------
https://chatgpt.com/codex/tasks/task_e_68f295e1a63883338b425f063eafdbc8