### PR TITLE
Enhance update output and restore settings updater

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -650,6 +650,17 @@
                 </div>
             </form>
         </div>
+        <div class="panel">
+            <h3>System-Update</h3>
+            <p class="muted">Spielt die neuesten Änderungen aus dem Repository ein. Es wird der gespeicherte API-Token als Update-Token verwendet.</p>
+            <div class="system-update-controls">
+                <p id="system-update-message" class="system-update-message small-text">Noch kein Update gestartet.</p>
+                <div id="system-update-log" class="system-update-log hidden"></div>
+                <div class="form-actions">
+                    <button type="button" id="run-system-update">Update starten</button>
+                </div>
+            </div>
+        </div>
     </section>
 
     <section id="guest-portal" data-section>

--- a/public/styles.css
+++ b/public/styles.css
@@ -727,6 +727,75 @@ button.status-action:disabled:hover {
     color: var(--muted);
 }
 
+.system-update-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.system-update-message {
+    margin: 0;
+}
+
+.system-update-message.info {
+    color: var(--muted);
+}
+
+.system-update-message.success {
+    color: #16a34a;
+}
+
+.system-update-message.error {
+    color: #dc2626;
+}
+
+.system-update-log {
+    border: 1px solid var(--border);
+    border-radius: .75rem;
+    overflow: hidden;
+    background: var(--surface-alt);
+}
+
+.system-update-log table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.system-update-log th,
+.system-update-log td {
+    padding: .75rem 1rem;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+    font-size: .9rem;
+}
+
+.system-update-log thead {
+    background: rgba(37, 99, 235, 0.08);
+}
+
+.system-update-log tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.system-update-log code {
+    display: inline-block;
+    padding: .15rem .4rem;
+    border-radius: .35rem;
+    background: rgba(15, 23, 42, 0.05);
+    font-size: .85rem;
+}
+
+.system-update-log pre {
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+    background: rgba(15, 23, 42, 0.05);
+    padding: .65rem .75rem;
+    border-radius: .5rem;
+    font-size: .85rem;
+    font-family: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
 .checkbox-inline {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- render a styled HTML status page from the update endpoint when the browser triggers it
- add a system update panel in the settings view that calls the backend updater with the stored token
- style the new settings controls and update log for clarity

## Testing
- php -l backend/update.php

------
https://chatgpt.com/codex/tasks/task_e_68f29a8126dc83339619bd45c856c671